### PR TITLE
Corrige visualización multicámara, navegación y alertas solo por correo

### DIFF
--- a/Cliente/App/detectionWindowDual.py
+++ b/Cliente/App/detectionWindowDual.py
@@ -36,6 +36,9 @@ class DetectionWindowDual(QMainWindow):
         
         self.detection_threads = detection_threads
         self.num_cameras = len(detection_threads)
+
+        # Evita preguntar dos veces al cerrar (botón -> close() -> closeEvent)
+        self._is_closing = False
         
         # Widgets para cada cámara
         self.camera_labels = {}
@@ -81,20 +84,23 @@ class DetectionWindowDual(QMainWindow):
             return rows, cols
     
     def calculate_camera_size(self):
-        """Calcular tamaño de cada cámara según el grid"""
-        # Tamaños base según número de cámaras
+        """Calcular tamaño de cada cámara según el grid.
+
+        Tamaños ajustados para que todas las cámaras quepan en pantalla
+        (la ventana se abre maximizada y el grid tiene scroll para el resto).
+        """
         if self.num_cameras == 1:
-            return 960, 720
+            return 900, 640
         elif self.num_cameras == 2:
-            return 640, 480
+            return 620, 460
         elif self.num_cameras <= 4:
-            return 560, 420
+            return 460, 345
         elif self.num_cameras <= 6:
-            return 480, 360
+            return 400, 300
         elif self.num_cameras <= 9:
-            return 420, 315
+            return 320, 240
         else:
-            return 380, 285
+            return 280, 210
     
     def setupUI(self):
         """Configurar interfaz de usuario DINÁMICA"""
@@ -206,6 +212,23 @@ class DetectionWindowDual(QMainWindow):
         button_layout = QHBoxLayout()
         button_layout.setSpacing(10)
         
+        # Botón Volver al Menú (regresa a la configuración de cámaras)
+        self.backButton = QPushButton("⬅ Volver al Menú")
+        self.backButton.setMinimumHeight(45)
+        self.backButton.setFont(QFont("Segoe UI", 10, QFont.Bold))
+        self.backButton.setStyleSheet("""
+            QPushButton {
+                background-color: #3498db;
+                color: white;
+                border: none;
+                border-radius: 5px;
+            }
+            QPushButton:hover {
+                background-color: #2980b9;
+            }
+        """)
+        self.backButton.clicked.connect(self.go_back)
+
         # Botón Pausar/Reanudar
         self.pauseButton = QPushButton("⏸ Pausar Sistema")
         self.pauseButton.setMinimumHeight(45)
@@ -240,6 +263,7 @@ class DetectionWindowDual(QMainWindow):
         """)
         self.stopButton.clicked.connect(self.stop_system)
         
+        button_layout.addWidget(self.backButton)
         button_layout.addStretch()
         button_layout.addWidget(self.pauseButton)
         button_layout.addWidget(self.stopButton)
@@ -247,17 +271,16 @@ class DetectionWindowDual(QMainWindow):
         main_layout.addLayout(button_layout)
         
         # ==========================================
-        # CONFIGURACIÓN DE VENTANA (TAMAÑO DINÁMICO)
+        # CONFIGURACIÓN DE VENTANA
         # ==========================================
-        # Calcular tamaño de ventana según grid
-        window_width = min(1920, (cam_width + 20) * self.grid_cols + 60)
-        window_height = min(1080, (cam_height + 100) * min(self.grid_rows, 3) + 300)
-        
         self.setWindowTitle(f"Monitoreo Activo - {self.num_cameras} Cámara(s)")
-        self.setMinimumSize(window_width, window_height)
-        
-        # Centrar en pantalla
-        self.center_window()
+
+        # Tamaño mínimo modesto y apertura MAXIMIZADA, para que TODAS las
+        # cámaras sean visibles (las que no quepan quedan accesibles con el
+        # scroll del grid). Antes la ventana se hacía más grande que la
+        # pantalla y las cámaras de la última fila quedaban fuera de vista.
+        self.setMinimumSize(900, 600)
+        self.setWindowState(Qt.WindowMaximized)
     
     def create_camera_widget(self, camera_id, width, height):
         """Crear widget para una cámara individual"""
@@ -435,28 +458,44 @@ class DetectionWindowDual(QMainWindow):
             self.system_status.setText("● SISTEMA ACTIVO")
             self.system_status.setStyleSheet("color: #27ae60;")
     
-    def stop_system(self):
-        """Detener sistema completo"""
+    def _shutdown_and_emit(self):
+        """Detener métricas y notificar para volver al menú (una sola vez).
+
+        El detener los threads de detección y el regreso a la ventana de
+        configuración los maneja main.py en on_detection_closed (conectado a
+        la señal `closed`).
+        """
+        if self._is_closing:
+            return
+        self._is_closing = True
+        self.metrics_timer.stop()
+        self.closed.emit()
+
+    def go_back(self):
+        """Volver al menú de configuración (detiene el monitoreo actual)"""
         reply = QMessageBox.question(
-            self, 'Confirmar',
-            '¿Desea detener el sistema de monitoreo?',
+            self, 'Volver al Menú',
+            '¿Volver al menú de configuración?\n\nSe detendrá el monitoreo actual.',
             QMessageBox.Yes | QMessageBox.No,
             QMessageBox.No
         )
-        
+
+        if reply == QMessageBox.Yes:
+            logging.info("Volviendo al menú de configuración...")
+            self._shutdown_and_emit()
+
+    def stop_system(self):
+        """Detener el monitoreo y volver al menú de configuración"""
+        reply = QMessageBox.question(
+            self, 'Detener Monitoreo',
+            '¿Desea detener el monitoreo y volver al menú de configuración?',
+            QMessageBox.Yes | QMessageBox.No,
+            QMessageBox.No
+        )
+
         if reply == QMessageBox.Yes:
             logging.info("Deteniendo sistema...")
-            
-            # Detener todos los threads
-            for detection in self.detection_threads.values():
-                detection.stop()
-                detection.wait(5000)
-            
-            self.metrics_timer.stop()
-            self.closed.emit()
-            self.close()
-            
-            logging.info("Sistema detenido correctamente")
+            self._shutdown_and_emit()
     
     def center_window(self):
         """Centrar ventana en pantalla"""
@@ -469,23 +508,22 @@ class DetectionWindowDual(QMainWindow):
         )
     
     def closeEvent(self, event):
-        """Manejar cierre de ventana"""
+        """Manejar cierre de ventana (botón X)"""
+        # Si ya estamos cerrando desde un botón, no volver a preguntar
+        if self._is_closing:
+            event.accept()
+            return
+
         reply = QMessageBox.question(
-            self, 'Confirmar Cierre',
-            '¿Está seguro de cerrar el sistema?',
+            self, 'Cerrar Monitoreo',
+            '¿Detener el monitoreo y volver al menú de configuración?',
             QMessageBox.Yes | QMessageBox.No,
             QMessageBox.No
         )
-        
+
         if reply == QMessageBox.Yes:
-            logging.info("Cerrando sistema - Usuario confirmó")
-            
-            for detection in self.detection_threads.values():
-                detection.stop()
-            
-            self.metrics_timer.stop()
-            self.closed.emit()
-            
+            logging.info("Cerrando monitoreo - Usuario confirmó")
+            self._shutdown_and_emit()
             event.accept()
         else:
             event.ignore()

--- a/Cliente/App/monitoringWindowClass.py
+++ b/Cliente/App/monitoringWindowClass.py
@@ -172,13 +172,13 @@ class MonitoringWindow(QMainWindow):
         global_group.setFont(QFont("Segoe UI", 11, QFont.Bold))
         global_layout = QFormLayout()
         
-        # Contacto para notificaciones
+        # Contacto para notificaciones (solo correo electrónico)
         self.receiveInput = QLineEdit()
-        self.receiveInput.setPlaceholderText("correo@ejemplo.com o +593987654321")
+        self.receiveInput.setPlaceholderText("correo@ejemplo.com")
         self.receiveInput.setFont(QFont("Segoe UI", 10))
         self.receiveInput.setMinimumHeight(40)
-        
-        global_layout.addRow("📧 Receptor de Alertas:", self.receiveInput)
+
+        global_layout.addRow("📧 Correo para Alertas:", self.receiveInput)
         global_group.setLayout(global_layout)
         main_layout.addWidget(global_group)
         
@@ -650,13 +650,28 @@ class MonitoringWindow(QMainWindow):
         msg = "RESULTADOS DE PRUEBA:\n\n" + "\n".join(results)
         QMessageBox.information(self, "Prueba de Cámaras", msg)
     
+    def _is_valid_email(self, text):
+        """Validación simple de correo electrónico"""
+        text = text.strip()
+        if '@' not in text:
+            return False
+        local, _, domain = text.partition('@')
+        return bool(local) and '.' in domain and not domain.startswith('.') and not domain.endswith('.')
+
     def start_monitoring_system(self):
         """Iniciar sistema de monitoreo multi-cámara"""
-        # Validar receptor
-        if not self.receiveInput.text():
+        # Validar correo de alertas (solo correo electrónico)
+        receiver = self.receiveInput.text().strip()
+        if not receiver:
             QMessageBox.warning(
                 self, "Campo Requerido",
-                "Ingrese un receptor para las alertas."
+                "Ingrese un correo electrónico para recibir las alertas."
+            )
+            return
+        if not self._is_valid_email(receiver):
+            QMessageBox.warning(
+                self, "Correo Inválido",
+                "Ingrese un correo electrónico válido.\n\nEjemplo: nombre@dominio.com"
             )
             return
         
@@ -686,7 +701,7 @@ class MonitoringWindow(QMainWindow):
         
         # Preparar configuración para enviar a main.py
         cameras_config = {
-            'receiver': self.receiveInput.text(),
+            'receiver': receiver,
             'token': self.token,
             'cameras': {}
         }

--- a/Cliente/UI/monitoringWindow.ui
+++ b/Cliente/UI/monitoringWindow.ui
@@ -143,7 +143,7 @@
      </font>
     </property>
     <property name="placeholderText">
-     <string>Ej: +593987654321 o email@empresa.com</string>
+     <string>Ej: email@empresa.com</string>
     </property>
    </widget>
    

--- a/Cliente/main.py
+++ b/Cliente/main.py
@@ -179,7 +179,7 @@ class MainApplication(QObject):
                 
                 # Crear instancia de DetectionTapo
                 detection = DetectionTapo(
-                    model_path='model/last.pt',
+                    model_path=GLOBAL_CONFIG['model_path'],
                     token=token,
                     location=config['location'],
                     receiver=receiver,
@@ -194,6 +194,9 @@ class MainApplication(QObject):
             logging.info(f"")
             logging.info("Creando ventana de visualización dual...")
             self.current_window = DetectionWindowDual(self.detection_threads)
+            # Al volver/detener desde la ventana de detección, regresar al menú
+            # de configuración (en vez de cerrar la app o la sesión).
+            self.current_window.closed.connect(self.on_detection_closed)
             self.current_window.show()
             
             logging.info("="*60)


### PR DESCRIPTION
## Resumen
Corrige tres problemas en el cliente de escritorio del sistema de detección de armas.

## Cambios

### 1. Visualización multicámara — se ven todas las cámaras
Antes, al configurar 3 o más cámaras solo aparecían algunas: la ventana de detección se hacía más grande que la pantalla y la última fila quedaba oculta (p. ej. con 3 cámaras, la 3.ª no se veía; con más, tampoco). Ahora la ventana **abre maximizada** y el grid de cámaras tiene **scroll**, por lo que se muestran **todas** las cámaras sin importar cuántas se agreguen. Se ajustaron los tamaños de cada cámara para 3 o más.

### 2. Navegación — volver al menú de configuración
La señal `closed` de la ventana de detección **nunca se conectaba** en `main.py`, por lo que cerrar la detección terminaba arrastrando a cerrar la sesión o la aplicación. Ahora:
- Nuevo botón **"⬅ Volver al Menú"**.
- **Detener Sistema** y el botón **X** también regresan al menú de configuración.
- Se conectó `closed → on_detection_closed` (que detiene los hilos y reabre el menú).
- Se eliminó el **doble diálogo** de confirmación al cerrar.

### 3. Alertas solo por correo electrónico
- El campo de receptor ya no admite número de celular: etiqueta y placeholder actualizados a correo (`📧 Correo para Alertas`).
- Se **valida el formato del correo** antes de iniciar el monitoreo (rechaza números de teléfono o texto inválido).

## Archivos modificados
- `Cliente/App/detectionWindowDual.py`
- `Cliente/App/monitoringWindowClass.py`
- `Cliente/main.py`
- `Cliente/UI/monitoringWindow.ui`

## Pruebas
Validado con pruebas automáticas (modo offscreen):
- 3 / 7 / 12 cámaras → se crean todos los widgets de video (grids 2×2, 3×3, 3×4).
- La señal de cierre se emite **una sola vez** (sin doble diálogo).
- La validación de correo acepta emails válidos y rechaza números de celular y texto sin formato.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
