### PR TITLE
Web Push (VAPID) + corrige auto-login tras reinicio

### DIFF
--- a/Server/alertuploadREST/views.py
+++ b/Server/alertuploadREST/views.py
@@ -30,12 +30,23 @@ def postAlert(request):
         serializer.save()
         print(f"Alerta guardada exitosamente. Datos: {serializer.data}")
         identify_email_sms(serializer)
+        # 🔔 Notificación Web Push al dueño de la alerta (en segundo plano)
+        send_web_push(serializer.instance)
 
     else:
         print(f"La validación del serializador falló: {serializer.errors}")
         return JsonResponse({'error':'¡No se pudieron procesar los datos!'},status=400)
 
     return Response(request.META.get('HTTP_AUTHORIZATION'))
+
+# Envía la notificación web push sin bloquear la respuesta HTTP
+@start_new_thread
+def send_web_push(alert_instance):
+    try:
+        from detection.webpush_sender import notify_alert_owner
+        notify_alert_owner(alert_instance)
+    except Exception as e:
+        print(f"Error al enviar notificación web push: {e}")
 
 # Identifica si el usuario proporcionó un correo electrónico o un número de teléfono
 def identify_email_sms(serializer):

--- a/Server/detection/admin.py
+++ b/Server/detection/admin.py
@@ -1,6 +1,13 @@
 from django.contrib import admin
 
-from detection.models import UploadAlert
+from detection.models import UploadAlert, PushSubscription
 
 # Register your models here.
 admin.site.register(UploadAlert)
+
+
+@admin.register(PushSubscription)
+class PushSubscriptionAdmin(admin.ModelAdmin):
+    list_display = ('user', 'endpoint', 'created')
+    search_fields = ('user__username', 'endpoint')
+    readonly_fields = ('created',)

--- a/Server/detection/management/commands/flush_all_sessions.py
+++ b/Server/detection/management/commands/flush_all_sessions.py
@@ -1,0 +1,26 @@
+"""
+Comando de gestión: flush_all_sessions
+
+Elimina TODAS las sesiones activas (logout global). Se ejecuta en el arranque
+en frío del servidor para garantizar que un reinicio NO deje ninguna sesión
+iniciada (evita el "auto-login" inseguro).
+
+A diferencia del comando integrado `clearsessions` (que solo borra las sesiones
+YA caducadas), este borra todas las filas de la tabla `django_session`.
+
+Uso:
+    python manage.py flush_all_sessions
+"""
+from django.contrib.sessions.models import Session
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+    help = "Elimina TODAS las sesiones activas (logout global) en el arranque en frío."
+
+    def handle(self, *args, **options):
+        total = Session.objects.count()
+        Session.objects.all().delete()
+        self.stdout.write(self.style.SUCCESS(
+            f"🔒 Sesiones eliminadas: {total}. El servidor exigirá login manual."
+        ))

--- a/Server/detection/management/commands/generate_vapid_keys.py
+++ b/Server/detection/management/commands/generate_vapid_keys.py
@@ -1,0 +1,52 @@
+"""
+Comando de gestión: generate_vapid_keys
+
+Genera un par de claves VAPID (curva P-256) para Web Push y las imprime en el
+formato que esperan tanto el navegador como `pywebpush`:
+
+  - VAPID_PUBLIC_KEY  -> punto público sin comprimir, base64url (applicationServerKey)
+  - VAPID_PRIVATE_KEY -> valor privado de 32 bytes, base64url
+
+Copia ambos valores en tu .env (local) y en las variables de entorno de Render.
+NO los subas al repositorio.
+
+Uso:
+    python manage.py generate_vapid_keys
+"""
+import base64
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from django.core.management.base import BaseCommand
+
+
+def _b64url(data: bytes) -> str:
+    """base64url sin relleno '=' (formato esperado por Web Push / VAPID)."""
+    return base64.urlsafe_b64encode(data).decode("utf-8").rstrip("=")
+
+
+class Command(BaseCommand):
+    help = "Genera un par de claves VAPID para notificaciones Web Push."
+
+    def handle(self, *args, **options):
+        private_key = ec.generate_private_key(ec.SECP256R1())
+
+        # Clave pública: punto sin comprimir (65 bytes) -> applicationServerKey
+        public_bytes = private_key.public_key().public_bytes(
+            serialization.Encoding.X962,
+            serialization.PublicFormat.UncompressedPoint,
+        )
+        public_b64 = _b64url(public_bytes)
+
+        # Clave privada: valor escalar de 32 bytes (lo que acepta pywebpush)
+        private_value = private_key.private_numbers().private_value
+        private_b64 = _b64url(private_value.to_bytes(32, "big"))
+
+        self.stdout.write(self.style.SUCCESS("\n✅ Par de claves VAPID generado.\n"))
+        self.stdout.write("Añade estas líneas a tu .env (y a las env vars de Render):\n")
+        self.stdout.write(self.style.HTTP_INFO(f"VAPID_PUBLIC_KEY={public_b64}"))
+        self.stdout.write(self.style.HTTP_INFO(f"VAPID_PRIVATE_KEY={private_b64}"))
+        self.stdout.write(self.style.HTTP_INFO("VAPID_ADMIN_EMAIL=mailto:tu-correo@dominio.com"))
+        self.stdout.write(self.style.WARNING(
+            "\n⚠️ Guarda la clave privada en secreto. No la subas al repositorio.\n"
+        ))

--- a/Server/detection/migrations/0002_pushsubscription.py
+++ b/Server/detection/migrations/0002_pushsubscription.py
@@ -1,0 +1,26 @@
+from django.conf import settings
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('detection', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='PushSubscription',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('endpoint', models.URLField(max_length=500, unique=True)),
+                ('p256dh', models.CharField(max_length=200)),
+                ('auth', models.CharField(max_length=100)),
+                ('user_agent', models.CharField(blank=True, default='', max_length=300)),
+                ('created', models.DateTimeField(auto_now_add=True)),
+                ('user', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='push_subscriptions', to=settings.AUTH_USER_MODEL)),
+            ],
+        ),
+    ]

--- a/Server/detection/models.py
+++ b/Server/detection/models.py
@@ -35,3 +35,18 @@ class UploadAlert(models.Model):
 def create_auth_token(sender, instance=None, created=False, **kwargs):
     if created:
         Token.objects.create(user=instance)
+
+
+# Web Push: suscripción del navegador asociada a un usuario.
+class PushSubscription(models.Model):
+    user = models.ForeignKey(
+        User, on_delete=models.CASCADE, related_name='push_subscriptions'
+    )
+    endpoint = models.URLField(max_length=500, unique=True)
+    p256dh = models.CharField(max_length=200)   # clave pública del cliente
+    auth = models.CharField(max_length=100)     # secreto de autenticación
+    user_agent = models.CharField(max_length=300, blank=True, default='')
+    created = models.DateTimeField(auto_now_add=True)
+
+    def __str__(self):
+        return f"PushSubscription({self.user.username})"

--- a/Server/detection/push_views.py
+++ b/Server/detection/push_views.py
@@ -1,0 +1,81 @@
+"""
+Vistas para Web Push (VAPID):
+  - public_key:  entrega la clave pública VAPID al navegador.
+  - subscribe:   guarda/actualiza la suscripción del usuario autenticado.
+  - unsubscribe: elimina la suscripción por su endpoint.
+  - service_worker: sirve /sw.js desde la raíz, con scope global.
+
+Las suscripciones quedan ligadas a request.user (sesión web), por lo que
+solo el dueño de la cuenta recibe sus alertas.
+"""
+import json
+import logging
+
+from django.conf import settings
+from django.contrib.auth.decorators import login_required
+from django.http import HttpResponse, JsonResponse
+from django.template.loader import render_to_string
+from django.views.decorators.http import require_GET, require_POST
+
+from .models import PushSubscription
+
+logger = logging.getLogger(__name__)
+
+
+@require_GET
+def public_key(request):
+    """Devuelve la clave pública VAPID (applicationServerKey) al cliente."""
+    return JsonResponse({'public_key': settings.VAPID_PUBLIC_KEY})
+
+
+@login_required(login_url='login')
+@require_POST
+def subscribe(request):
+    """Registra la suscripción push del usuario autenticado."""
+    try:
+        data = json.loads(request.body.decode('utf-8'))
+        endpoint = data['endpoint']
+        keys = data['keys']
+        p256dh = keys['p256dh']
+        auth = keys['auth']
+    except (ValueError, KeyError, TypeError):
+        return JsonResponse({'error': 'Suscripción inválida'}, status=400)
+
+    PushSubscription.objects.update_or_create(
+        endpoint=endpoint,
+        defaults={
+            'user': request.user,
+            'p256dh': p256dh,
+            'auth': auth,
+            'user_agent': request.META.get('HTTP_USER_AGENT', '')[:300],
+        },
+    )
+    logger.info("🔔 Suscripción push registrada para %s", request.user.username)
+    return JsonResponse({'ok': True})
+
+
+@login_required(login_url='login')
+@require_POST
+def unsubscribe(request):
+    """Elimina la suscripción push por su endpoint."""
+    try:
+        data = json.loads(request.body.decode('utf-8'))
+        endpoint = data['endpoint']
+    except (ValueError, KeyError, TypeError):
+        return JsonResponse({'error': 'Petición inválida'}, status=400)
+
+    PushSubscription.objects.filter(endpoint=endpoint, user=request.user).delete()
+    return JsonResponse({'ok': True})
+
+
+@require_GET
+def service_worker(request):
+    """
+    Sirve el Service Worker desde la raíz (/sw.js) para que su scope sea '/'.
+    La cabecera Service-Worker-Allowed permite controlar todo el sitio.
+    """
+    body = render_to_string('detection/sw.js')
+    response = HttpResponse(body, content_type='application/javascript')
+    response['Service-Worker-Allowed'] = '/'
+    response['Cache-Control'] = 'no-cache'
+    return response

--- a/Server/detection/templates/detection/main.html
+++ b/Server/detection/templates/detection/main.html
@@ -25,7 +25,9 @@
 
 	{% endblock %}
     </div>
-	
+
+	<!-- Web Push (VAPID): registro del Service Worker y suscripción -->
+	<script src="{% static '/js/push.js' %}"></script>
 </body>
 
 <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>

--- a/Server/detection/templates/detection/navbar.html
+++ b/Server/detection/templates/detection/navbar.html
@@ -231,6 +231,11 @@
         ¡Hola, {{ request.user }}!
       </li>
       <li>
+        <button id="enablePushBtn" type="button" class="logout-btn" style="background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%); border: none; cursor: pointer;">
+          🔔 Activar notificaciones
+        </button>
+      </li>
+      <li>
         <a class="logout-btn" href="{% url 'logout' %}">
           <i class="fas fa-sign-out-alt"></i>
           Cerrar sesión
@@ -256,47 +261,9 @@
       }
     });
 
-    // Variable para controlar navegación interna
-    let isInternalNavigation = false;
-
-    // Detectar navegación interna
-    const internalLinks = document.querySelectorAll('a[href^="/"], a[href*="{% url"]');
-    internalLinks.forEach(link => {
-        link.addEventListener('click', function() {
-            isInternalNavigation = true;
-            setTimeout(() => {
-                isInternalNavigation = false;
-            }, 100);
-        });
-    });
-
-    // Auto-logout inteligente (solo al cerrar pestaña real)
-    window.addEventListener('beforeunload', function(e) {
-        if (!isInternalNavigation) {
-            const logoutUrl = "{% url 'logout' %}";
-            const csrfToken = document.querySelector('[name=csrfmiddlewaretoken]')?.value || 
-                             document.querySelector('meta[name=csrf-token]')?.getAttribute('content');
-            
-            if (navigator.sendBeacon && csrfToken) {
-                const formData = new FormData();
-                formData.append('csrfmiddlewaretoken', csrfToken);
-                navigator.sendBeacon(logoutUrl, formData);
-            }
-        }
-    });
-
-    window.addEventListener('pagehide', function(e) {
-        if (e.persisted === false && !isInternalNavigation) {
-            const logoutUrl = "{% url 'logout' %}";
-            const csrfToken = document.querySelector('[name=csrfmiddlewaretoken]')?.value || 
-                             document.querySelector('meta[name=csrf-token]')?.getAttribute('content');
-            
-            if (navigator.sendBeacon && csrfToken) {
-                const formData = new FormData();
-                formData.append('csrfmiddlewaretoken', csrfToken);
-                navigator.sendBeacon(logoutUrl, formData);
-            }
-        }
-    });
+    // NOTA: el cierre de sesión al cerrar el navegador ahora lo gestiona el
+    // servidor con SESSION_EXPIRE_AT_BROWSER_CLOSE (+ borrado de sesiones en el
+    // arranque). Se eliminó el parche con sendBeacon/beforeunload por redundante
+    // y poco fiable.
   });
 </script>

--- a/Server/detection/templates/detection/sw.js
+++ b/Server/detection/templates/detection/sw.js
@@ -1,0 +1,44 @@
+/* Service Worker - Weapon Detection System (Web Push)
+ * Servido desde /sw.js (scope raíz) por detection.push_views.service_worker.
+ */
+
+// Recibe un mensaje push y muestra la notificación del sistema.
+self.addEventListener('push', function (event) {
+  let data = {};
+  try {
+    data = event.data ? event.data.json() : {};
+  } catch (e) {
+    data = { title: 'Alerta de seguridad', body: event.data ? event.data.text() : '' };
+  }
+
+  const title = data.title || '🚨 Alerta de seguridad';
+  const options = {
+    body: data.body || 'Se ha detectado un arma en el sistema de vigilancia.',
+    icon: data.icon || '/static/img/icon.png',
+    badge: data.badge || '/static/img/badge.png',
+    tag: data.tag || 'weapon-alert',
+    requireInteraction: true,
+    data: { url: data.url || '/' }
+  };
+
+  event.waitUntil(self.registration.showNotification(title, options));
+});
+
+// Al hacer clic en la notificación, enfoca o abre la pestaña de la alerta.
+self.addEventListener('notificationclick', function (event) {
+  event.notification.close();
+  const targetUrl = (event.notification.data && event.notification.data.url) || '/';
+
+  event.waitUntil(
+    clients.matchAll({ type: 'window', includeUncontrolled: true }).then(function (windowClients) {
+      for (const client of windowClients) {
+        if (client.url.indexOf(targetUrl) !== -1 && 'focus' in client) {
+          return client.focus();
+        }
+      }
+      if (clients.openWindow) {
+        return clients.openWindow(targetUrl);
+      }
+    })
+  );
+});

--- a/Server/detection/urls.py
+++ b/Server/detection/urls.py
@@ -1,5 +1,6 @@
 from django.urls import path
 from . import views
+from . import push_views
 from django.contrib.auth import views as auth_views
 
 urlpatterns = [
@@ -7,6 +8,12 @@ urlpatterns = [
     path('register/', views.registerPage, name='register'),
     path('', views.home, name='home'),
     path('logout/', views.logoutUser, name='logout'),
+
+    # 🔔 Web Push (VAPID)
+    path('sw.js', push_views.service_worker, name='service_worker'),
+    path('push/public_key/', push_views.public_key, name='push_public_key'),
+    path('push/subscribe/', push_views.subscribe, name='push_subscribe'),
+    path('push/unsubscribe/', push_views.unsubscribe, name='push_unsubscribe'),
 
     # ✅ PASSWORD RESET con envío asíncrono (Gmail SMTP)
     path('reset_password/',

--- a/Server/detection/views.py
+++ b/Server/detection/views.py
@@ -5,6 +5,7 @@ from django.contrib.auth.forms import UserCreationForm
 from django.contrib.auth import authenticate, login, logout
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
+from django.views.decorators.csrf import ensure_csrf_cookie
 
 from .forms import CreateUserForm
 from .filters import DetectionFilter
@@ -71,6 +72,7 @@ def logoutUser(request):
 	return redirect('login')
 
 @login_required(login_url='login')
+@ensure_csrf_cookie
 def home(request):
     # Obtener el token del usuario
     token = Token.objects.get(user=request.user)

--- a/Server/detection/webpush_sender.py
+++ b/Server/detection/webpush_sender.py
@@ -1,0 +1,86 @@
+"""
+Envío de notificaciones Web Push (VAPID) con pywebpush.
+
+send_push_to_user(user, payload) recorre todas las suscripciones del usuario y
+les entrega el mensaje. Las suscripciones caducadas (404/410) se eliminan.
+"""
+import json
+import logging
+
+from django.conf import settings
+
+from .models import PushSubscription
+
+logger = logging.getLogger(__name__)
+
+
+def send_push_to_user(user, payload: dict) -> int:
+    """
+    Envía una notificación push a todas las suscripciones de `user`.
+    Devuelve el número de envíos correctos.
+    """
+    if not settings.VAPID_PRIVATE_KEY or not settings.VAPID_PUBLIC_KEY:
+        logger.warning("⚠️ VAPID no configurado: se omite el envío de push.")
+        return 0
+
+    # Import diferido para no romper el arranque si la librería no está instalada.
+    try:
+        from pywebpush import webpush, WebPushException
+    except ImportError:
+        logger.error("❌ pywebpush no está instalado; no se envían notificaciones push.")
+        return 0
+
+    subscriptions = PushSubscription.objects.filter(user=user)
+    sent = 0
+
+    for sub in subscriptions:
+        try:
+            webpush(
+                subscription_info={
+                    "endpoint": sub.endpoint,
+                    "keys": {"p256dh": sub.p256dh, "auth": sub.auth},
+                },
+                data=json.dumps(payload),
+                vapid_private_key=settings.VAPID_PRIVATE_KEY,
+                vapid_claims={"sub": settings.VAPID_ADMIN_EMAIL},
+            )
+            sent += 1
+        except WebPushException as exc:
+            status = getattr(exc.response, "status_code", None)
+            if status in (404, 410):
+                # Suscripción muerta: eliminar.
+                logger.info("🧹 Suscripción push caducada eliminada (%s).", status)
+                sub.delete()
+            else:
+                logger.error("❌ Error enviando push: %s", exc)
+        except Exception as exc:  # noqa: BLE001 - no debe interrumpir la alerta
+            logger.error("❌ Error inesperado enviando push: %s", exc)
+
+    logger.info("🔔 Push enviadas a %s: %s/%s", user.username, sent, subscriptions.count())
+    return sent
+
+
+def notify_alert_owner(alert_instance):
+    """
+    Envía una push al dueño de la alerta (UploadAlert.userID -> Token -> User).
+    Se llama desde el flujo de subida de alertas.
+    """
+    try:
+        token = alert_instance.userID            # FK a authtoken.Token
+        user = token.user
+    except Exception as exc:  # noqa: BLE001
+        logger.error("❌ No se pudo resolver el dueño de la alerta para push: %s", exc)
+        return 0
+
+    # Construir la URL de la alerta a partir del nombre de imagen (uuid.jpg).
+    image_name = getattr(alert_instance.image, "name", "") or ""
+    alert_id = image_name.split("/")[-1].rsplit(".", 1)[0] if image_name else ""
+    url = f"/alert/{alert_id}/" if alert_id else "/"
+
+    payload = {
+        "title": "🚨 Arma detectada",
+        "body": f"Ubicación: {alert_instance.location}",
+        "url": url,
+        "tag": f"weapon-alert-{alert_id or 'na'}",
+    }
+    return send_push_to_user(user, payload)

--- a/Server/docs/NOTIFICACIONES_PUSH_Y_SESIONES.md
+++ b/Server/docs/NOTIFICACIONES_PUSH_Y_SESIONES.md
@@ -1,0 +1,128 @@
+# Notificaciones Web Push (VAPID) y endurecimiento de sesiones
+
+Este documento describe dos cambios en el servidor Django:
+
+1. **Notificaciones Web Push** con el estándar VAPID.
+2. **Corrección del auto-login** tras reiniciar el servidor (seguridad de sesiones).
+
+---
+
+## 1. Notificaciones Web Push (VAPID)
+
+### Por qué VAPID y no FCM
+- Estándar abierto (Web Push Protocol RFC 8030 + VAPID RFC 8292), soportado por
+  Chrome, Edge, Firefox y Safari 16+.
+- No requiere proyecto Firebase ni SDK externo: generas tu propio par de claves.
+- Las librerías (`pywebpush`, `py-vapid`) ya estaban en `requirements.txt`.
+
+### Arquitectura
+- **Destino de la notificación:** el *dueño de la alerta*
+  (`UploadAlert.userID` → `authtoken.Token` → `User`).
+- Las suscripciones del navegador se guardan en el modelo `PushSubscription`,
+  ligadas al usuario de la sesión web.
+- El envío ocurre en el flujo de subida de alertas (`POST /api/images/`), en un
+  hilo en segundo plano, junto al email/SMS ya existentes.
+
+### Componentes
+| Componente | Ruta |
+|-----------|------|
+| Comando para generar claves | `detection/management/commands/generate_vapid_keys.py` |
+| Modelo de suscripción | `detection/models.py` (`PushSubscription`) |
+| Endpoints (clave pública / suscribir / desuscribir) | `detection/push_views.py` |
+| Service Worker (servido en `/sw.js`, scope raíz) | `detection/templates/detection/sw.js` |
+| Frontend (registro + suscripción) | `static/js/push.js` |
+| Envío server-side | `detection/webpush_sender.py` |
+
+### Rutas nuevas
+- `GET  /sw.js` — Service Worker (cabecera `Service-Worker-Allowed: /`).
+- `GET  /push/public_key/` — entrega la clave pública VAPID.
+- `POST /push/subscribe/` — guarda la suscripción (requiere login + CSRF).
+- `POST /push/unsubscribe/` — elimina la suscripción.
+
+### Variables de entorno (NO se suben al repo)
+Genera el par de claves:
+```bash
+cd Server
+python manage.py generate_vapid_keys
+```
+Copia el resultado en `Server/.env` (local) y en las *Environment Variables* de Render:
+```
+VAPID_PUBLIC_KEY=<clave_publica_base64url>
+VAPID_PRIVATE_KEY=<clave_privada_base64url>
+VAPID_ADMIN_EMAIL=mailto:tu-correo@dominio.com
+```
+> Si `VAPID_*` está vacío, el envío de push se omite con un *warning*; el resto del
+> flujo de alertas (email/SMS) sigue funcionando.
+
+### Migración
+Se añade la tabla `PushSubscription`:
+```bash
+python manage.py migrate
+```
+
+### Cómo probar
+1. Arranca el servidor e inicia sesión en el dashboard (HTTPS o `localhost`).
+2. Pulsa **🔔 Activar notificaciones** y acepta el permiso del navegador.
+3. Dispara una alerta (cliente PyQt o `POST /api/images/` con el token del usuario).
+4. Llega la notificación del sistema aunque la pestaña esté en segundo plano; al
+   hacer clic abre `/alert/<id>/`.
+
+Ejemplo de prueba de la API:
+```bash
+curl -X POST https://<host>/api/images/ \
+  -H "Authorization: Token <token_del_usuario>" \
+  -F "userID=<token_del_usuario>" -F "alertReceiver=correo@dominio.com" \
+  -F "location=Entrada" -F "image=@prueba.jpg"
+```
+
+---
+
+## 2. Corrección del auto-login (seguridad de sesiones)
+
+### Problema
+Django usa por defecto **sesiones en base de datos** y una **cookie persistente**
+(`SESSION_EXPIRE_AT_BROWSER_CLOSE=False`, edad por defecto de 2 semanas). Al
+reiniciar el servidor, la sesión seguía viva en la BD y el navegador conservaba la
+cookie → el usuario entraba **sin pedir credenciales**.
+
+### Solución
+- **`settings.py`**: la sesión termina al cerrar el navegador, caduca por
+  inactividad (30 min, deslizante) y endurece la cookie:
+  ```python
+  SESSION_EXPIRE_AT_BROWSER_CLOSE = True
+  SESSION_COOKIE_AGE = 1800
+  SESSION_SAVE_EVERY_REQUEST = True
+  SESSION_COOKIE_HTTPONLY = True
+  SESSION_COOKIE_SAMESITE = 'Lax'
+  SESSION_COOKIE_SECURE = os.environ.get('SECURE_COOKIES', 'False').lower() == 'true'
+  CSRF_COOKIE_SECURE   = os.environ.get('SECURE_COOKIES', 'False').lower() == 'true'
+  ```
+- **Comando `flush_all_sessions`**: borra TODAS las sesiones activas (logout global).
+- **Arranque en frío sin sesiones**:
+  - *Producción/Render*: el hook `on_starting()` de `gunicorn_config.py` borra todas
+    las sesiones una sola vez en el proceso maestro, antes de crear los workers.
+  - *Local*: `start.ps1` / `start.sh` ejecutan `flush_all_sessions` y luego `runserver`.
+
+### Variables de entorno (producción)
+En Render, añade:
+```
+SECURE_COOKIES=true
+```
+para que las cookies de sesión y CSRF viajen solo por HTTPS.
+
+### Cómo probar
+1. Inicia sesión en la web.
+2. Detén el servidor y vuelve a arrancarlo (`./start.ps1` en local).
+3. Recarga: te redirige a `/login/` (ya no entra solo).
+
+> Comando manual de verificación (servidor parado):
+> ```bash
+> python manage.py flush_all_sessions   # -> "🔒 Sesiones eliminadas: N"
+> ```
+
+### Nota sobre Render
+Asegúrate de que el *Start Command* use el archivo de configuración para que el
+hook de limpieza se ejecute:
+```
+gunicorn webdev.wsgi -c gunicorn_config.py
+```

--- a/Server/gunicorn_config.py
+++ b/Server/gunicorn_config.py
@@ -124,6 +124,24 @@ def on_starting(server):
     print(f"   Max requests: {max_requests}")
     print("="*60 + "\n")
 
+    # ============================================
+    # 🔒 SEGURIDAD: arranque en frío sin sesiones
+    # ============================================
+    # Borra TODAS las sesiones activas una sola vez, en el proceso maestro,
+    # antes de crear los workers. Así, tras un reinicio/deploy del servidor,
+    # nadie queda autenticado y se exige login manual (evita el auto-login).
+    try:
+        os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'webdev.settings')
+        import django
+        django.setup()
+        from django.contrib.sessions.models import Session
+        total = Session.objects.count()
+        Session.objects.all().delete()
+        print(f"🔒 Arranque en frío: {total} sesión(es) eliminada(s). Se exigirá login.\n")
+    except Exception as e:
+        # No abortar el arranque si la BD aún no está disponible.
+        print(f"⚠️ No se pudieron limpiar las sesiones al arrancar: {e}\n")
+
 
 def on_reload(server):
     """Se ejecuta cuando se recarga la aplicación"""

--- a/Server/start.ps1
+++ b/Server/start.ps1
@@ -1,0 +1,11 @@
+# Arranque local en frío (Windows / PowerShell)
+# Borra todas las sesiones ANTES de levantar el servidor para que el
+# reinicio exija login manual, y luego ejecuta runserver.
+#
+# Uso:  ./start.ps1   (desde la carpeta Server)
+
+$ErrorActionPreference = "Stop"
+Set-Location -Path $PSScriptRoot
+
+python manage.py flush_all_sessions
+python manage.py runserver

--- a/Server/start.sh
+++ b/Server/start.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Arranque local en frío (Linux / macOS / Git Bash)
+# Borra todas las sesiones ANTES de levantar el servidor para que el
+# reinicio exija login manual, y luego ejecuta runserver.
+#
+# Uso:  bash start.sh   (desde la carpeta Server)
+set -o errexit
+
+cd "$(dirname "$0")"
+
+python manage.py flush_all_sessions
+python manage.py runserver

--- a/Server/static/js/push.js
+++ b/Server/static/js/push.js
@@ -1,0 +1,116 @@
+/* push.js - Suscripción a Web Push (VAPID) desde el dashboard.
+ * Registra el Service Worker, pide permiso y envía la suscripción al servidor.
+ */
+(function () {
+  'use strict';
+
+  // --- utilidades ---------------------------------------------------------
+  function urlBase64ToUint8Array(base64String) {
+    const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
+    const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
+    const raw = window.atob(base64);
+    const output = new Uint8Array(raw.length);
+    for (let i = 0; i < raw.length; ++i) {
+      output[i] = raw.charCodeAt(i);
+    }
+    return output;
+  }
+
+  function getCookie(name) {
+    const match = document.cookie.match('(^|;)\\s*' + name + '\\s*=\\s*([^;]+)');
+    return match ? match.pop() : '';
+  }
+
+  function setButtonState(btn, text, disabled) {
+    if (!btn) return;
+    btn.textContent = text;
+    btn.disabled = !!disabled;
+  }
+
+  // --- flujo principal ----------------------------------------------------
+  async function subscribeUser(btn) {
+    try {
+      if (!('serviceWorker' in navigator) || !('PushManager' in window)) {
+        alert('Tu navegador no soporta notificaciones push.');
+        return;
+      }
+
+      setButtonState(btn, 'Activando…', true);
+
+      const registration = await navigator.serviceWorker.register('/sw.js', { scope: '/' });
+      await navigator.serviceWorker.ready;
+
+      const permission = await Notification.requestPermission();
+      if (permission !== 'granted') {
+        alert('Permiso de notificaciones denegado.');
+        setButtonState(btn, '🔔 Activar notificaciones', false);
+        return;
+      }
+
+      // Obtener la clave pública VAPID del servidor.
+      const keyResp = await fetch('/push/public_key/');
+      const keyData = await keyResp.json();
+      if (!keyData.public_key) {
+        alert('El servidor no tiene configurada la clave VAPID.');
+        setButtonState(btn, '🔔 Activar notificaciones', false);
+        return;
+      }
+
+      // Reutilizar suscripción existente o crear una nueva.
+      let subscription = await registration.pushManager.getSubscription();
+      if (!subscription) {
+        subscription = await registration.pushManager.subscribe({
+          userVisibleOnly: true,
+          applicationServerKey: urlBase64ToUint8Array(keyData.public_key)
+        });
+      }
+
+      // Enviar la suscripción al servidor.
+      const resp = await fetch('/push/subscribe/', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRFToken': getCookie('csrftoken')
+        },
+        body: JSON.stringify(subscription)
+      });
+
+      if (resp.ok) {
+        setButtonState(btn, '✅ Notificaciones activas', true);
+      } else {
+        setButtonState(btn, '🔔 Activar notificaciones', false);
+        alert('No se pudo registrar la suscripción en el servidor.');
+      }
+    } catch (err) {
+      console.error('Error al activar notificaciones push:', err);
+      setButtonState(btn, '🔔 Activar notificaciones', false);
+      alert('Ocurrió un error al activar las notificaciones.');
+    }
+  }
+
+  // Si ya está suscrito, refleja el estado en el botón al cargar.
+  async function refreshButton(btn) {
+    if (!('serviceWorker' in navigator) || !('PushManager' in window)) {
+      setButtonState(btn, 'Push no soportado', true);
+      return;
+    }
+    try {
+      const registration = await navigator.serviceWorker.getRegistration('/');
+      if (registration) {
+        const sub = await registration.pushManager.getSubscription();
+        if (sub && Notification.permission === 'granted') {
+          setButtonState(btn, '✅ Notificaciones activas', true);
+        }
+      }
+    } catch (e) {
+      // silencioso
+    }
+  }
+
+  document.addEventListener('DOMContentLoaded', function () {
+    const btn = document.getElementById('enablePushBtn');
+    if (!btn) return;
+    refreshButton(btn);
+    btn.addEventListener('click', function () { subscribeUser(btn); });
+  });
+})();

--- a/Server/webdev/settings.py
+++ b/Server/webdev/settings.py
@@ -60,6 +60,24 @@ MIDDLEWARE = [
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
 
+# ==========================================
+# 🔐 SEGURIDAD DE SESIONES
+# ==========================================
+# Evita el "auto-login" tras reiniciar el servidor:
+#  - La sesión termina al cerrar el navegador.
+#  - Caduca por inactividad (expiración deslizante).
+#  - Además, todas las sesiones se borran en el arranque en frío
+#    (ver `flush_all_sessions` + hook `on_starting` de gunicorn_config.py).
+SESSION_EXPIRE_AT_BROWSER_CLOSE = True   # cerrar el navegador termina la sesión
+SESSION_COOKIE_AGE = 1800                # 30 min de inactividad
+SESSION_SAVE_EVERY_REQUEST = True        # expiración deslizante (se renueva con actividad)
+SESSION_COOKIE_HTTPONLY = True
+SESSION_COOKIE_SAMESITE = 'Lax'
+# Cookies solo por HTTPS en producción. Se activa con SECURE_COOKIES=true
+# (p. ej. en Render); por defecto False para no romper el desarrollo local en http.
+SESSION_COOKIE_SECURE = os.environ.get('SECURE_COOKIES', 'False').lower() == 'true'
+CSRF_COOKIE_SECURE = os.environ.get('SECURE_COOKIES', 'False').lower() == 'true'
+
 ROOT_URLCONF = 'webdev.urls'
 
 TEMPLATES = [
@@ -226,3 +244,15 @@ AWS_DEFAULT_ACL=None
 PUBLIC_MEDIA_LOCATION = 'media'
 MEDIA_URL = f'https://{AWS_S3_CUSTOM_DOMAIN}/{PUBLIC_MEDIA_LOCATION}/'
 DEFAULT_FILE_STORAGE = 'webdev.storage_backends.PublicMediaStorage'
+
+# ==========================================
+# 🔔 WEB PUSH (VAPID)
+# ==========================================
+# Claves del par VAPID para notificaciones Web Push (estándar abierto, sin FCM).
+# Genera el par con:  python manage.py generate_vapid_keys
+# y guarda los valores en variables de entorno (.env local / env vars en Render).
+# NUNCA hardcodear estas claves en el repositorio.
+VAPID_PUBLIC_KEY = os.environ.get('VAPID_PUBLIC_KEY', '')
+VAPID_PRIVATE_KEY = os.environ.get('VAPID_PRIVATE_KEY', '')
+# El claim "sub" del JWT VAPID: un mailto o una URL de contacto del responsable.
+VAPID_ADMIN_EMAIL = os.environ.get('VAPID_ADMIN_EMAIL', 'mailto:admin@weapondetection.com')


### PR DESCRIPTION
## Resumen

Implementa dos cosas en el servidor Django:

1. **Notificaciones Web Push (VAPID)** dirigidas al dueño de la alerta.
2. **Corrección del auto-login inseguro** tras reiniciar el servidor.

Documentación completa en `Server/docs/NOTIFICACIONES_PUSH_Y_SESIONES.md`.

---

## 🔔 Tarea 1 — Web Push (VAPID)

Elegido **Web Push API con VAPID** (estándar abierto, sin Firebase/FCM). Las librerías `pywebpush`/`py-vapid` ya estaban en `requirements.txt`.

- Modelo `PushSubscription` (+ migración `0002`) y registro en admin.
- Endpoints: `GET /push/public_key/`, `POST /push/subscribe/`, `POST /push/unsubscribe/` y `GET /sw.js` (Service Worker en scope raíz).
- Comando `python manage.py generate_vapid_keys` para generar el par de claves.
- Envío server-side con `pywebpush` (`detection/webpush_sender.py`), enganchado en `postAlert`; la notificación llega al **dueño de la alerta** (`UploadAlert.userID` → `Token` → `User`).
- Frontend `static/js/push.js` + botón **🔔 Activar notificaciones** en el navbar.
- Claves VAPID por **variables de entorno** (`VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY`, `VAPID_ADMIN_EMAIL`). Nada hardcodeado.

## 🔐 Tarea 2 — Corrige el auto-login tras reinicio

**Causa:** sesiones en BD + cookie persistente por defecto → al reiniciar el servidor la sesión seguía viva y entraba sin credenciales.

**Solución:**
- `settings.py`: `SESSION_EXPIRE_AT_BROWSER_CLOSE`, caducidad por inactividad (deslizante), cookies `HttpOnly`/`SameSite`/`Secure` (esta última por env `SECURE_COOKIES`).
- Comando `flush_all_sessions` (logout global) + borrado en el **arranque en frío** vía el hook `on_starting` de `gunicorn_config.py`.
- Scripts `start.ps1` / `start.sh` para desarrollo local.
- Eliminado el parche cliente `sendBeacon` del navbar (redundante).

---

## ✅ Cómo probar

**Sesiones:** login → reiniciar servidor (`./start.ps1`) → recargar redirige a `/login/`.

**Push:**
1. `python manage.py generate_vapid_keys` → pegar las 3 líneas en `.env` (y env vars de Render).
2. `python manage.py migrate`.
3. Login en el dashboard (HTTPS o `localhost`) → **Activar notificaciones**.
4. Disparar una alerta (`POST /api/images/`) → llega la notificación del sistema.

## ⚠️ Notas de despliegue (Render)
- Añadir env vars: `VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY`, `VAPID_ADMIN_EMAIL`, `SECURE_COOKIES=true`.
- Aplicar la migración `0002` (el `build.sh` ya ejecuta `migrate`).
- *Start Command* con `-c gunicorn_config.py` para que se ejecute la limpieza de sesiones al arrancar.

> No se incluyen en este PR los cambios previos no relacionados de `Cliente/cameras.json` ni `Server/build.sh`.

