### PR TITLE
Refactor cliente: motor de inferencia YOLO compartido + multi-marca RTSP

### DIFF
--- a/Cliente/App/__init__.py
+++ b/Cliente/App/__init__.py
@@ -13,12 +13,14 @@ from .detection_tapo import DetectionTapo
 from .detectionWindowDual import DetectionWindowDual
 from .loginWindowClass import LoginWindow
 from .monitoringWindowClass import MonitoringWindow
-from .cameraManagerWindow import CameraManagerWindow 
+from .cameraManagerWindow import CameraManagerWindow
+from .inference_engine import InferenceEngine
 
 __all__ = [
     'DetectionTapo',
     'DetectionWindowDual',
-    'LoginWindow', 
+    'LoginWindow',
     'MonitoringWindow',
-    'CameraManagerWindow' 
+    'CameraManagerWindow',
+    'InferenceEngine'
 ]

--- a/Cliente/App/cameraManagerWindow.py
+++ b/Cliente/App/cameraManagerWindow.py
@@ -16,6 +16,9 @@ from PyQt5.QtGui import QFont
 import logging
 import cv2
 
+from .rtsp_fields import RtspFieldsGroup
+from . import rtsp_profiles as profiles
+
 
 class AddCameraDialog(QDialog):
     """Diálogo para agregar/editar una cámara"""
@@ -26,7 +29,7 @@ class AddCameraDialog(QDialog):
         self.is_edit = is_edit
         
         self.setWindowTitle("✏️ Editar Cámara" if is_edit else "➕ Agregar Nueva Cámara")
-        self.setMinimumWidth(500)
+        self.setMinimumWidth(580)
         
         self.setupUI()
         
@@ -37,79 +40,44 @@ class AddCameraDialog(QDialog):
         """Configurar interfaz del diálogo"""
         layout = QVBoxLayout(self)
         layout.setSpacing(15)
-        
+
         # Título
         title = QLabel("➕ Nueva Cámara" if not self.is_edit else "✏️ Editar Cámara")
         title.setFont(QFont("Segoe UI", 14, QFont.Bold))
         title.setAlignment(Qt.AlignCenter)
         layout.addWidget(title)
-        
-        # Formulario
+
+        # Identificación (nombre + ubicación + estado)
         form_group = QGroupBox("📋 Información de la Cámara")
         form_group.setFont(QFont("Segoe UI", 10, QFont.Bold))
         form_layout = QFormLayout()
         form_layout.setSpacing(12)
-        
+
         # Nombre
         self.name_input = QLineEdit()
         self.name_input.setPlaceholderText("Ej: Cámara Entrada Principal")
         self.name_input.setMinimumHeight(35)
         form_layout.addRow("🏷️ Nombre:", self.name_input)
-        
-        # IP
-        self.ip_input = QLineEdit()
-        self.ip_input.setPlaceholderText("192.168.1.10")
-        self.ip_input.setMinimumHeight(35)
-        form_layout.addRow("🌐 Dirección IP:", self.ip_input)
-        
-        # Usuario
-        self.user_input = QLineEdit()
-        self.user_input.setPlaceholderText("Usuario de Camera Account")
-        self.user_input.setMinimumHeight(35)
-        form_layout.addRow("👤 Usuario:", self.user_input)
-        
-        # Contraseña
-        self.pass_input = QLineEdit()
-        self.pass_input.setPlaceholderText("Contraseña")
-        self.pass_input.setMinimumHeight(35)
-        self.pass_input.setEchoMode(QLineEdit.Password)
-        
-        show_pass = QCheckBox("Mostrar contraseña")
-        show_pass.stateChanged.connect(
-            lambda state: self.pass_input.setEchoMode(
-                QLineEdit.Normal if state == Qt.Checked else QLineEdit.Password
-            )
-        )
-        
-        pass_layout = QHBoxLayout()
-        pass_layout.addWidget(self.pass_input)
-        pass_layout.addWidget(show_pass)
-        form_layout.addRow("🔒 Contraseña:", pass_layout)
-        
+
         # Ubicación
         self.location_input = QLineEdit()
         self.location_input.setPlaceholderText("Ej: Entrada Principal, Piso 2")
         self.location_input.setMinimumHeight(35)
         form_layout.addRow("📍 Ubicación:", self.location_input)
-        
-        # Stream
-        self.stream_combo = QComboBox()
-        self.stream_combo.addItems([
-            "Alta Calidad (stream1) - 2304x1296",
-            "Baja Calidad (stream2) - 640x360"
-        ])
-        self.stream_combo.setMinimumHeight(35)
-        form_layout.addRow("📺 Calidad:", self.stream_combo)
-        
+
         # Habilitada
         self.enabled_check = QCheckBox("Habilitar esta cámara")
         self.enabled_check.setChecked(True)
         self.enabled_check.setFont(QFont("Segoe UI", 10))
         form_layout.addRow("✅ Estado:", self.enabled_check)
-        
+
         form_group.setLayout(form_layout)
         layout.addWidget(form_group)
-        
+
+        # Conexión RTSP (marca, IP, puerto, usuario, contraseña, canal, calidad, ruta)
+        self.fields = RtspFieldsGroup(self)
+        layout.addWidget(self.fields)
+
         # Botón de prueba
         test_btn = QPushButton("🔧 Probar Conexión")
         test_btn.setMinimumHeight(40)
@@ -141,31 +109,26 @@ class AddCameraDialog(QDialog):
     def load_camera_data(self):
         """Cargar datos de cámara existente"""
         self.name_input.setText(self.camera_data.get('name', ''))
-        self.ip_input.setText(self.camera_data.get('ip', ''))
-        self.user_input.setText(self.camera_data.get('username', ''))
-        self.pass_input.setText(self.camera_data.get('password', ''))
         self.location_input.setText(self.camera_data.get('location', ''))
         self.enabled_check.setChecked(self.camera_data.get('enabled', True))
-        
-        if self.camera_data.get('stream') == 'stream2':
-            self.stream_combo.setCurrentIndex(1)
-    
+        self.fields.set_config(self.camera_data)
+
     def test_connection(self):
         """Probar conexión con los datos ingresados"""
-        ip = self.ip_input.text()
-        user = self.user_input.text()
-        password = self.pass_input.text()
-        stream = 'stream1' if self.stream_combo.currentIndex() == 0 else 'stream2'
-        
+        cfg = self.fields.get_config()
+        ip = cfg['ip']
+        user = cfg['username']
+        password = cfg['password']
+
         if not ip or not user or not password:
             QMessageBox.warning(
                 self, "Campos Incompletos",
                 "Complete IP, usuario y contraseña para probar."
             )
             return
-        
-        rtsp_url = f"rtsp://{user}:{password}@{ip}:554/{stream}"
-        
+
+        rtsp_url = self.fields.rtsp_url()
+
         try:
             os.environ["OPENCV_FFMPEG_CAPTURE_OPTIONS"] = (
                 "rtsp_transport;udp|fflags;nobuffer|flags;low_delay"
@@ -184,7 +147,7 @@ class AddCameraDialog(QDialog):
                         f"¡Cámara conectada correctamente!\n\n"
                         f"Resolución: {width}x{height}\n"
                         f"IP: {ip}\n"
-                        f"Stream: {stream}"
+                        f"Marca: {profiles.brand_label(cfg['brand'])}"
                     )
                 else:
                     QMessageBox.warning(
@@ -211,40 +174,47 @@ class AddCameraDialog(QDialog):
     
     def validate_and_accept(self):
         """Validar datos antes de aceptar"""
+        cfg = self.fields.get_config()
+
         if not self.name_input.text():
             QMessageBox.warning(self, "Campo Requerido", "Ingrese un nombre para la cámara.")
             return
-        
-        if not self.ip_input.text():
-            QMessageBox.warning(self, "Campo Requerido", "Ingrese la dirección IP.")
-            return
-        
-        if not self.user_input.text():
-            QMessageBox.warning(self, "Campo Requerido", "Ingrese el usuario.")
-            return
-        
-        if not self.pass_input.text():
-            QMessageBox.warning(self, "Campo Requerido", "Ingrese la contraseña.")
-            return
-        
+
         if not self.location_input.text():
             QMessageBox.warning(self, "Campo Requerido", "Ingrese la ubicación.")
             return
-        
+
+        if profiles.brand_uses_custom_path(cfg['brand']):
+            # Marca genérica: basta con una ruta/URL RTSP (puede traer su propia IP/credenciales).
+            if not cfg['path']:
+                QMessageBox.warning(self, "Campo Requerido",
+                                    "Ingrese la ruta RTSP (o pegue la URL rtsp:// completa).")
+                return
+            if not str(cfg['path']).lower().startswith('rtsp://') and not cfg['ip']:
+                QMessageBox.warning(self, "Campo Requerido", "Ingrese la dirección IP.")
+                return
+        else:
+            if not cfg['ip']:
+                QMessageBox.warning(self, "Campo Requerido", "Ingrese la dirección IP.")
+                return
+            if not cfg['username']:
+                QMessageBox.warning(self, "Campo Requerido", "Ingrese el usuario.")
+                return
+            if not cfg['password']:
+                QMessageBox.warning(self, "Campo Requerido", "Ingrese la contraseña.")
+                return
+
         self.accept()
-    
+
     def get_camera_data(self):
-        """Obtener datos de la cámara"""
-        return {
+        """Obtener datos de la cámara (identificación + conexión RTSP)."""
+        data = {
             'name': self.name_input.text(),
-            'ip': self.ip_input.text(),
-            'username': self.user_input.text(),
-            'password': self.pass_input.text(),
             'location': self.location_input.text(),
-            'stream': 'stream1' if self.stream_combo.currentIndex() == 0 else 'stream2',
-            'port': 554,
-            'enabled': self.enabled_check.isChecked()
+            'enabled': self.enabled_check.isChecked(),
         }
+        data.update(self.fields.get_config())
+        return data
 
 
 class CameraManagerWindow(QDialog):
@@ -377,18 +347,20 @@ class CameraManagerWindow(QDialog):
         details_layout.setSpacing(12)
         
         self.detail_name = QLabel("---")
+        self.detail_brand = QLabel("---")
         self.detail_ip = QLabel("---")
         self.detail_user = QLabel("---")
         self.detail_location = QLabel("---")
         self.detail_stream = QLabel("---")
         self.detail_status = QLabel("---")
-        
-        for label in [self.detail_name, self.detail_ip, self.detail_user,
+
+        for label in [self.detail_name, self.detail_brand, self.detail_ip, self.detail_user,
                       self.detail_location, self.detail_stream, self.detail_status]:
             label.setFont(QFont("Segoe UI", 10))
             label.setWordWrap(True)
-        
+
         details_layout.addRow("🏷️ Nombre:", self.detail_name)
+        details_layout.addRow("📷 Marca:", self.detail_brand)
         details_layout.addRow("🌐 IP:", self.detail_ip)
         details_layout.addRow("👤 Usuario:", self.detail_user)
         details_layout.addRow("📍 Ubicación:", self.detail_location)
@@ -529,14 +501,16 @@ class CameraManagerWindow(QDialog):
         cam = self.cameras[key]
         
         self.detail_name.setText(cam.get('name', '---'))
+        self.detail_brand.setText(profiles.brand_label(cam.get('brand', 'tapo')))
         self.detail_ip.setText(cam.get('ip', '---'))
         self.detail_user.setText(cam.get('username', '---'))
         self.detail_location.setText(cam.get('location', '---'))
-        
-        stream = cam.get('stream', 'stream1')
-        stream_text = "Alta Calidad (stream1)" if stream == 'stream1' else "Baja Calidad (stream2)"
-        self.detail_stream.setText(stream_text)
-        
+
+        quality = profiles.normalize_quality(cam)
+        self.detail_stream.setText(
+            "Principal (alta calidad)" if quality == 'main' else "Secundaria (baja calidad)"
+        )
+
         enabled = cam.get('enabled', True)
         self.detail_status.setText("✅ Habilitada" if enabled else "⚪ Deshabilitada")
     
@@ -602,7 +576,7 @@ class CameraManagerWindow(QDialog):
             self.update_camera_list()
             
             # Limpiar detalles
-            for label in [self.detail_name, self.detail_ip, self.detail_user,
+            for label in [self.detail_name, self.detail_brand, self.detail_ip, self.detail_user,
                           self.detail_location, self.detail_stream, self.detail_status]:
                 label.setText("---")
     
@@ -615,19 +589,15 @@ class CameraManagerWindow(QDialog):
         
         key = items[0].data(Qt.UserRole)
         cam = self.cameras[key]
-        
+
         ip = cam.get('ip')
-        user = cam.get('username')
-        password = cam.get('password')
-        stream = cam.get('stream', 'stream1')
-        
-        rtsp_url = f"rtsp://{user}:{password}@{ip}:554/{stream}"
-        
+        rtsp_url = profiles.build_rtsp_url(cam)
+
         try:
             os.environ["OPENCV_FFMPEG_CAPTURE_OPTIONS"] = (
                 "rtsp_transport;udp|fflags;nobuffer|flags;low_delay"
             )
-            
+
             cap = cv2.VideoCapture(rtsp_url, cv2.CAP_FFMPEG)
             
             if cap.isOpened():

--- a/Cliente/App/cameras_config.py
+++ b/Cliente/App/cameras_config.py
@@ -26,6 +26,10 @@ GLOBAL_CONFIG = {
     'use_gpu': True,
     'max_detections': 10,
     'confidence_threshold': 0.5,
+
+    # Motor de inferencia compartido: nº de workers de inferencia (1 modelo en RAM
+    # para todas las cámaras). Default 1; subir a 2 solo si la GPU lo permite.
+    'inference_workers': 1,
     
     # Recuperación de errores
     'max_reconnect_attempts': 3,

--- a/Cliente/App/detection_tapo.py
+++ b/Cliente/App/detection_tapo.py
@@ -13,8 +13,6 @@ from collections import deque
 from PyQt5.QtCore import QThread, pyqtSignal, Qt
 from PyQt5.QtGui import QImage
 import cv2
-from ultralytics import YOLO
-import numpy as np
 import psutil
 import GPUtil
 import requests
@@ -34,46 +32,45 @@ class DetectionTapo(QThread):
     weaponDetected = pyqtSignal(str)
     statusUpdate = pyqtSignal(str)
     
-    def __init__(self, model_path, token, location, receiver, camera_config, camera_id=1):
+    def __init__(self, model_path, token, location, receiver, camera_config, camera_id=1, engine=None):
         super(DetectionTapo, self).__init__()
-        
+
         # Identificación
         self.camera_id = camera_id
         self.camera_name = camera_config.get('name', f'Camera {camera_id}')
-        
+
         # Configuración básica
         self.model_path = model_path
-        self.colors = {0: (0, 0, 255), 1: (0, 165, 255)}
         self.token = token
         self.location = location
         self.receiver = receiver
-        
+
+        # Motor de inferencia COMPARTIDO (1 modelo para todas las cámaras).
+        # La inferencia ya no ocurre en esta clase: se delega al engine.
+        self.engine = engine
+
         # Configuración de cámara
         self.camera_config = camera_config
         self.rtsp_url = self._build_rtsp_url()
-        
+
         # Control de ejecución
         self.running = False
         self.cap = None
-        self.model = None
-        
+
         # OPTIMIZACIÓN: Intervalos ajustados para máxima velocidad
-        self.analysis_interval = 2  # Analizar cada 2 segundos (antes 3)
+        self.analysis_interval = 2  # Enviar frame a análisis cada 2 segundos
         self.last_analysis_time = 0
-        self.capture_interval = 4   # Enviar detecciones cada 4 segundos (antes 5)
+        self.capture_interval = 4   # Enviar detecciones cada 4 segundos
         self.last_capture_time = 0
-        self.resource_check_interval = 10  # Verificar recursos cada 10s (antes 5)
+        self.resource_check_interval = 10  # Verificar recursos cada 10s
         self.last_resource_check = 0
-        
-        # OPTIMIZACIÓN: Sistema de colas sin buffer (máximo 1 frame pendiente)
+
+        # Cola de captura sin buffer (máximo 1 frame pendiente) para el video en vivo
         self.frame_queue = Queue(maxsize=1)
-        self.analysis_queue = Queue(maxsize=1)
-        
-        # OPTIMIZACIÓN: Threads independientes
+
+        # Thread de captura (el de análisis ya no existe: lo maneja el engine)
         self.capture_thread = None
-        self.analysis_thread = None
-        self.analysis_running = False
-        
+
         # OPTIMIZACIÓN: Frame skipping inteligente
         self.frame_counter = 0
         self.skip_frames = 0  # Procesar todos los frames para UI
@@ -95,32 +92,26 @@ class DetectionTapo(QThread):
         logging.info(f"[Cámara {self.camera_id}] Ubicación: {self.location}")
     
     def _build_rtsp_url(self):
-        """Construir URL RTSP optimizada"""
-        cfg = self.camera_config
-        username = cfg.get('username', 'admin')
-        password = cfg.get('password', '')
-        ip = cfg.get('ip')
-        port = cfg.get('port', 554)
-        stream = cfg.get('stream', 'stream1')
-        
-        return f"rtsp://{username}:{password}@{ip}:{port}/{stream}"
+        """Construir URL RTSP según la marca de la cámara (Tapo, Hikvision, Dahua, etc.)."""
+        from .rtsp_profiles import build_rtsp_url
+        return build_rtsp_url(self.camera_config)
     
     def run(self):
         """Thread principal de ejecución OPTIMIZADO"""
         self.running = True
-        
-        # Cargar modelo YOLO una sola vez
-        if not self._load_model():
-            return
-        
+
         # Inicializar cámara con máxima optimización
         if not self._initialize_rtsp_camera_optimized():
             return
-        
-        # OPTIMIZACIÓN: Iniciar threads de captura y análisis
+
+        # Registrar esta cámara en el motor de inferencia compartido para
+        # recibir SIEMPRE los resultados de sus propias capturas (por camera_id).
+        if self.engine:
+            self.engine.register(self.camera_id, self.on_inference_result)
+
+        # Iniciar SOLO el thread de captura (el análisis lo hace el engine)
         self._start_capture_thread()
-        self._start_analysis_thread()
-        
+
         # OPTIMIZACIÓN: Loop principal solo para UI (máxima responsividad)
         retry_count = 0
         max_retries = 3
@@ -138,10 +129,11 @@ class DetectionTapo(QThread):
                     # Actualizar FPS
                     self._update_fps()
                     
-                    # Enviar a análisis cada N segundos
+                    # Enviar frame al motor de inferencia compartido cada N segundos
                     current_time = time.time()
                     if (current_time - self.last_analysis_time) >= self.analysis_interval:
-                        self._queue_frame_for_analysis(frame.copy())
+                        if self.engine:
+                            self.engine.submit(self.camera_id, frame.copy())
                         self.last_analysis_time = current_time
                     
                     # Verificar recursos (menos frecuente)
@@ -162,24 +154,7 @@ class DetectionTapo(QThread):
                 break
         
         self.cleanup()
-    
-    def _load_model(self):
-        """Cargar modelo YOLO con optimizaciones"""
-        try:
-            self.model = YOLO(self.model_path)
-            
-            # OPTIMIZACIÓN: Configurar modelo para inferencia rápida
-            self.model.fuse()  # Fusionar capas para velocidad
-            
-            logging.info(f"[Cámara {self.camera_id}] Modelo YOLO cargado y optimizado")
-            return True
-        except Exception as e:
-            error_msg = f"[Cámara {self.camera_id}] Error al cargar YOLO: {str(e)}"
-            self.error.emit(error_msg)
-            logging.error(error_msg)
-            self.running = False
-            return False
-    
+
     def _initialize_rtsp_camera_optimized(self):
         """Inicializar cámara RTSP con MÁXIMA OPTIMIZACIÓN"""
         try:
@@ -306,110 +281,27 @@ class DetectionTapo(QThread):
             self.reconnect_attempts = 0
             logging.info(f"[Cámara {self.camera_id}] Reconexión exitosa")
     
-    def _start_analysis_thread(self):
-        """Iniciar thread de análisis YOLO"""
-        self.analysis_running = True
-        self.analysis_thread = threading.Thread(
-            target=self._analysis_worker_optimized, 
-            daemon=True,
-            name=f"Analysis-Cam{self.camera_id}"
-        )
-        self.analysis_thread.start()
-        logging.info(f"[Cámara {self.camera_id}] Thread de análisis iniciado")
-    
-    def _analysis_worker_optimized(self):
-        """Worker de análisis OPTIMIZADO"""
-        logging.info(f"[Cámara {self.camera_id}] Análisis worker iniciado")
-        
-        while self.analysis_running:
-            try:
-                if self.analysis_queue.empty():
-                    time.sleep(0.1)
-                    continue
-                
-                frame = self.analysis_queue.get(timeout=1)
-                
-                # OPTIMIZACIÓN: Análisis YOLO con configuración rápida
-                self._analyze_frame_fast(frame)
-                
-            except Empty:
-                continue
-            except Exception as e:
-                logging.error(f"[Cámara {self.camera_id}] Error en análisis: {e}")
-                time.sleep(0.1)
-        
-        logging.info(f"[Cámara {self.camera_id}] Análisis worker detenido")
-    
-    def _queue_frame_for_analysis(self, frame):
-        """Agregar frame a cola de análisis SIN BLOQUEO"""
-        try:
-            if self.analysis_queue.full():
-                try:
-                    self.analysis_queue.get_nowait()
-                except:
-                    pass
-            self.analysis_queue.put_nowait(frame)
-        except:
-            pass
-    
-    def _analyze_frame_fast(self, frame):
-        """Análisis YOLO OPTIMIZADO"""
-        try:
-            # OPTIMIZACIÓN: Inferencia rápida
-            results = self.model(
-                frame,
-                verbose=False,
-                conf=0.5,           # Confianza mínima
-                iou=0.45,           # IoU para NMS
-                max_det=10,         # Máximo 10 detecciones
-                half=False,         # Usar FP16 si tienes GPU
-                device='0' if self._has_gpu() else 'cpu'
-            )
-            
-            detected_objects = []
-            for result in results:
-                boxes = result.boxes
-                for box in boxes:
-                    conf = float(box.conf[0])
-                    cls = int(box.cls[0])
-                    
-                    detected_objects.append({
-                        'class': cls,
-                        'confidence': conf,
-                        'box': box.xyxy[0].tolist()
-                    })
-                    
-                    # Dibujar en frame
-                    x1, y1, x2, y2 = map(int, box.xyxy[0])
-                    cv2.rectangle(frame, (x1, y1), (x2, y2), 
-                                self.colors.get(cls, (255, 0, 0)), 2)
-                    
-                    label = f"{self.model.names[cls]} {conf:.2f}"
-                    cv2.putText(frame, label, (x1, y1-10),
-                              cv2.FONT_HERSHEY_SIMPLEX, 0.5, 
-                              self.colors.get(cls, (255, 0, 0)), 2)
-            
-            if detected_objects:
-                msg = f"[Cámara {self.camera_id}] {len(detected_objects)} objetos detectados"
-                logging.info(msg)
-                self.weaponDetected.emit(msg)
-                
-                # Guardar y enviar
-                current_time = time.time()
-                if (current_time - self.last_capture_time) >= self.capture_interval:
-                    self.saveDetection(frame, detected_objects)
-                    self.last_capture_time = current_time
-                    
-        except Exception as e:
-            logging.error(f"[Cámara {self.camera_id}] Error en análisis YOLO: {e}")
-    
-    def _has_gpu(self):
-        """Verificar si hay GPU disponible"""
-        try:
-            gpus = GPUtil.getGPUs()
-            return len(gpus) > 0
-        except:
-            return False
+    def on_inference_result(self, annotated_frame, detections):
+        """Callback que invoca el motor de inferencia con el resultado de ESTA cámara.
+
+        Corre en el hilo del worker del engine (NO en el hilo Qt). Es seguro porque:
+        - emitir señales Qt entre hilos es thread-safe (conexión en cola),
+        - saveDetection solo escribe un archivo y lanza su propio hilo de subida
+          (no toca widgets),
+        - last_capture_time lo escribe solo este callback (worker único por cámara).
+        """
+        if not detections:
+            return
+
+        msg = f"[Cámara {self.camera_id}] {len(detections)} objetos detectados"
+        logging.info(msg)
+        self.weaponDetected.emit(msg)
+
+        # Guardar y enviar (rate-limitado por capture_interval), igual que antes
+        current_time = time.time()
+        if (current_time - self.last_capture_time) >= self.capture_interval:
+            self.saveDetection(annotated_frame, detections)
+            self.last_capture_time = current_time
     
     def update_ui(self, frame):
         """Actualizar UI OPTIMIZADO"""
@@ -523,32 +415,32 @@ class DetectionTapo(QThread):
     def cleanup(self):
         """Limpiar recursos"""
         logging.info(f"[Cámara {self.camera_id}] Limpiando recursos...")
-        
-        self.analysis_running = False
-        
-        # Esperar threads
-        if self.analysis_thread and self.analysis_thread.is_alive():
-            self.analysis_thread.join(timeout=2)
-        
+
+        # Dar de baja del motor de inferencia (deja de recibir resultados)
+        if self.engine:
+            self.engine.unregister(self.camera_id)
+
+        # Esperar thread de captura
         if self.capture_thread and self.capture_thread.is_alive():
             self.capture_thread.join(timeout=2)
-        
-        # Limpiar colas
-        for queue in [self.analysis_queue, self.frame_queue]:
-            while not queue.empty():
-                try:
-                    queue.get_nowait()
-                except:
-                    break
-        
+
+        # Limpiar cola de captura
+        while not self.frame_queue.empty():
+            try:
+                self.frame_queue.get_nowait()
+            except Empty:
+                break
+
         # Liberar cámara
         if self.cap:
             self.cap.release()
-        
+
         logging.info(f"[Cámara {self.camera_id}] Recursos liberados")
-    
+
     def stop(self):
         """Detener detección"""
         self.running = False
-        self.analysis_running = False
+        # Dar de baja del engine de inmediato para no entregar resultados a una cámara detenida
+        if self.engine:
+            self.engine.unregister(self.camera_id)
         logging.info(f"[Cámara {self.camera_id}] Deteniendo...")

--- a/Cliente/App/inference_engine.py
+++ b/Cliente/App/inference_engine.py
@@ -1,0 +1,305 @@
+# -*- coding: utf-8 -*-
+"""
+inference_engine.py - MOTOR DE INFERENCIA YOLO COMPARTIDO
+
+En lugar de cargar el modelo YOLO una vez por cámara (N copias en RAM/VRAM),
+se carga UNA sola vez y se comparte entre todas las cámaras mediante:
+  - una cola central thread-safe de trabajos (camera_id),
+  - un set de "último frame por cámara" (descarta frames viejos -> sin backlog),
+  - uno o más workers (default 1) que ejecutan la inferencia por turnos y
+    devuelven el resultado a la cámara correcta vía callback registrado por id.
+
+El monitoreo NO se reduce: cada cámara registrada recibe SIEMPRE sus resultados
+(enrutado por camera_id). Solo se comparte el modelo, no la cobertura.
+
+Además instrumenta tiempos (inferencia y espera en cola) por cámara para poder
+documentar el rendimiento real.
+"""
+
+import os
+import sys
+import csv
+import time
+import threading
+import logging
+from queue import Queue
+
+import cv2
+from ultralytics import YOLO
+
+try:
+    import GPUtil
+except Exception:  # GPUtil es opcional
+    GPUtil = None
+
+
+def _app_dir():
+    """Directorio base (compatible con PyInstaller frozen y desarrollo)."""
+    if getattr(sys, 'frozen', False):
+        return os.path.dirname(sys.executable)
+    return os.path.abspath('.')
+
+
+class InferenceEngine:
+    """Motor de inferencia compartido entre todas las cámaras."""
+
+    _SENTINEL = object()
+
+    def __init__(self, model_path, conf=0.5, iou=0.45, max_det=10,
+                 num_workers=1, metrics_csv='inference_metrics.csv'):
+        self.model_path = model_path
+        self.conf = conf
+        self.iou = iou
+        self.max_det = max_det
+        self.num_workers = max(1, int(num_workers))
+
+        self.model = None
+        self.device = 'cpu'
+        self.colors = {0: (0, 0, 255), 1: (0, 165, 255)}
+
+        # Cola central + estado compartido (protegido por _lock)
+        self._jobs = Queue()
+        self._latest = {}        # camera_id -> (frame, submit_time)
+        self._callbacks = {}     # camera_id -> callable(annotated_frame, detections)
+        self._pending = set()    # camera_ids encolados y aún sin tomar (evita duplicados)
+        self._inflight = set()   # camera_ids que un worker está procesando AHORA
+        self._lock = threading.Lock()
+
+        self._workers = []
+        self._running = False
+
+        # Métricas por cámara (protegidas por _metrics_lock)
+        self._metrics = {}       # camera_id -> {'infer': [...], 'queue': [...], 'count': int}
+        self._metrics_lock = threading.Lock()
+
+        # CSV de métricas (para la tesis). Best-effort.
+        self._metrics_csv_path = os.path.join(_app_dir(), metrics_csv) if metrics_csv else None
+        self._csv_file = None
+        self._csv_writer = None
+
+    # ------------------------------------------------------------------ ciclo de vida
+    def start(self):
+        """Carga el modelo UNA sola vez y arranca el/los worker(s)."""
+        if self._running:
+            return
+        logging.info(f"[Engine] Cargando modelo (1 sola vez): {self.model_path}")
+        self.model = YOLO(self.model_path)
+        try:
+            self.model.fuse()  # fusiona capas (1 sola vez)
+        except Exception as e:
+            logging.warning(f"[Engine] fuse() falló, continúo: {e}")
+
+        self.device = '0' if self._detect_gpu() else 'cpu'
+        self._open_metrics_csv()
+
+        self._running = True
+        for i in range(self.num_workers):
+            t = threading.Thread(target=self._run, name=f"InferenceWorker-{i}", daemon=True)
+            t.start()
+            self._workers.append(t)
+
+        logging.info(f"[Engine] Listo. device={self.device}, workers={self.num_workers}")
+
+    def stop(self, timeout=5):
+        """Apagado limpio: detiene workers (sentinela) y libera el modelo."""
+        if not self._running and not self._workers:
+            return
+        self._running = False
+        for _ in self._workers:
+            self._jobs.put(self._SENTINEL)
+        for t in self._workers:
+            t.join(timeout=timeout)
+        self._workers = []
+        self.model = None
+        self._close_metrics_csv()
+        logging.info("[Engine] Detenido y modelo liberado")
+
+    def _detect_gpu(self):
+        if GPUtil is None:
+            return False
+        try:
+            return len(GPUtil.getGPUs()) > 0
+        except Exception:
+            return False
+
+    # ------------------------------------------------------------------ registro / envío
+    def register(self, camera_id, callback):
+        """Registrar el callback de una cámara. Garantiza que esa cámara recibirá sus resultados."""
+        with self._lock:
+            self._callbacks[camera_id] = callback
+        with self._metrics_lock:
+            self._metrics.setdefault(camera_id, {'infer': [], 'queue': [], 'count': 0})
+        logging.info(f"[Engine] Cámara {camera_id} registrada")
+
+    def unregister(self, camera_id):
+        """Quitar una cámara (al detenerla) para no entregarle resultados ya muerta."""
+        with self._lock:
+            self._callbacks.pop(camera_id, None)
+            self._latest.pop(camera_id, None)
+            self._pending.discard(camera_id)
+        logging.info(f"[Engine] Cámara {camera_id} dada de baja")
+
+    def submit(self, camera_id, frame):
+        """Encolar el frame más reciente de una cámara (descarta el anterior sin procesar)."""
+        if not self._running:
+            return
+        with self._lock:
+            self._latest[camera_id] = (frame, time.time())
+            # Encolar solo si no está ya pendiente NI siendo procesado por un worker.
+            # Esto evita que (con num_workers>1) dos workers procesen la misma cámara
+            # en paralelo. Los frames que lleguen mientras está en proceso solo
+            # actualizan _latest; al terminar, el worker re-encola si hay uno más nuevo.
+            if camera_id not in self._pending and camera_id not in self._inflight:
+                self._pending.add(camera_id)
+                self._jobs.put(camera_id)
+
+    # ------------------------------------------------------------------ worker
+    def _run(self):
+        """Loop del worker: toma un camera_id, analiza su frame más reciente y entrega el resultado."""
+        logging.info(f"[Engine] Worker iniciado: {threading.current_thread().name}")
+        while True:
+            cid = self._jobs.get()
+            if cid is self._SENTINEL:
+                break
+
+            with self._lock:
+                self._pending.discard(cid)
+                # Si otro worker ya está procesando esta cámara, no la dupliques.
+                if cid in self._inflight:
+                    continue
+                item = self._latest.get(cid)
+                callback = self._callbacks.get(cid)
+                if item is None or callback is None:
+                    continue
+                # Reservar la cámara: solo UN worker la procesa a la vez.
+                self._inflight.add(cid)
+                frame, submit_time = item
+
+            queue_wait = time.time() - submit_time
+            t0 = time.time()
+            try:
+                annotated, detections = self._infer(frame)
+                infer_time = time.time() - t0
+                self._record_metrics(cid, infer_time, queue_wait)
+                # El callback corre en el hilo del worker (NO en el hilo Qt).
+                # DetectionTapo solo emite señales (thread-safe) y guarda/sube.
+                callback(annotated, detections)
+            except Exception as e:
+                logging.error(f"[Engine] Error procesando cámara {cid}: {e}")
+            finally:
+                with self._lock:
+                    self._inflight.discard(cid)
+                    # Si llegó un frame MÁS NUEVO mientras procesábamos, re-encolar
+                    # (para no perder el frame más reciente bajo carga).
+                    latest = self._latest.get(cid)
+                    if (latest is not None and latest[1] > submit_time
+                            and cid not in self._pending and cid in self._callbacks):
+                        self._pending.add(cid)
+                        self._jobs.put(cid)
+
+        logging.info(f"[Engine] Worker detenido: {threading.current_thread().name}")
+
+    def _infer(self, frame):
+        """Inferencia YOLO + dibujo de recuadros. Device cacheado (no GPUtil por frame)."""
+        results = self.model(
+            frame,
+            verbose=False,
+            conf=self.conf,
+            iou=self.iou,
+            max_det=self.max_det,
+            half=False,
+            device=self.device
+        )
+
+        detected = []
+        for result in results:
+            for box in result.boxes:
+                conf = float(box.conf[0])
+                cls = int(box.cls[0])
+                detected.append({
+                    'class': cls,
+                    'confidence': conf,
+                    'box': box.xyxy[0].tolist()
+                })
+                x1, y1, x2, y2 = map(int, box.xyxy[0])
+                color = self.colors.get(cls, (255, 0, 0))
+                cv2.rectangle(frame, (x1, y1), (x2, y2), color, 2)
+                label = f"{self.model.names[cls]} {conf:.2f}"
+                cv2.putText(frame, label, (x1, y1 - 10),
+                            cv2.FONT_HERSHEY_SIMPLEX, 0.5, color, 2)
+
+        return frame, detected
+
+    # ------------------------------------------------------------------ métricas (FASE 2)
+    def _record_metrics(self, camera_id, infer_time, queue_wait):
+        with self._metrics_lock:
+            m = self._metrics.setdefault(camera_id, {'infer': [], 'queue': [], 'count': 0})
+            m['infer'].append(infer_time)
+            m['queue'].append(queue_wait)
+            m['count'] += 1
+        logging.info(
+            f"[Metrics] cam={camera_id} inferencia={infer_time * 1000:.1f}ms "
+            f"cola={queue_wait * 1000:.1f}ms"
+        )
+        self._write_metrics_csv(camera_id, infer_time, queue_wait)
+
+    def get_metrics_summary(self):
+        """Resumen consultable por cámara: count + promedio/min/max de inferencia y cola (ms)."""
+        out = {}
+        with self._metrics_lock:
+            for cid, m in self._metrics.items():
+                inf, q = m['infer'], m['queue']
+                if inf:
+                    out[cid] = {
+                        'count': m['count'],
+                        'infer_avg_ms': 1000 * sum(inf) / len(inf),
+                        'infer_min_ms': 1000 * min(inf),
+                        'infer_max_ms': 1000 * max(inf),
+                        'queue_avg_ms': 1000 * sum(q) / len(q),
+                        'queue_min_ms': 1000 * min(q),
+                        'queue_max_ms': 1000 * max(q),
+                    }
+                else:
+                    out[cid] = {'count': 0}
+        return out
+
+    def _open_metrics_csv(self):
+        if not self._metrics_csv_path:
+            return
+        try:
+            new_file = not os.path.exists(self._metrics_csv_path)
+            self._csv_file = open(self._metrics_csv_path, 'a', newline='', encoding='utf-8')
+            self._csv_writer = csv.writer(self._csv_file)
+            if new_file:
+                self._csv_writer.writerow(['timestamp', 'camera_id', 'inferencia_ms', 'cola_ms'])
+                self._csv_file.flush()
+            logging.info(f"[Engine] Métricas CSV: {self._metrics_csv_path}")
+        except Exception as e:
+            logging.warning(f"[Engine] No se pudo abrir CSV de métricas: {e}")
+            self._csv_file = None
+            self._csv_writer = None
+
+    def _write_metrics_csv(self, camera_id, infer_time, queue_wait):
+        if not self._csv_writer:
+            return
+        try:
+            with self._metrics_lock:
+                self._csv_writer.writerow([
+                    time.strftime("%Y-%m-%d %H:%M:%S"),
+                    camera_id,
+                    f"{infer_time * 1000:.1f}",
+                    f"{queue_wait * 1000:.1f}",
+                ])
+                self._csv_file.flush()
+        except Exception:
+            pass
+
+    def _close_metrics_csv(self):
+        try:
+            if self._csv_file:
+                self._csv_file.close()
+        except Exception:
+            pass
+        finally:
+            self._csv_file = None
+            self._csv_writer = None

--- a/Cliente/App/monitoringWindowClass.py
+++ b/Cliente/App/monitoringWindowClass.py
@@ -16,6 +16,9 @@ from PyQt5.QtGui import QFont, QIcon
 import logging
 import cv2
 
+from .rtsp_fields import RtspFieldsGroup
+from . import rtsp_profiles as profiles
+
 # Importar el gestor de cámaras
 try:
     from .cameraManagerWindow import CameraManagerWindow
@@ -331,63 +334,10 @@ class MonitoringWindow(QMainWindow):
         tab_layout.addWidget(status_group)
         
         # ==========================================
-        # CONFIGURACIÓN RTSP
+        # CONFIGURACIÓN RTSP (marca, IP, puerto, usuario, contraseña, canal, calidad, ruta)
         # ==========================================
-        rtsp_group = QGroupBox("🌐 Configuración de Red")
-        rtsp_group.setFont(QFont("Segoe UI", 11, QFont.Bold))
-        rtsp_group.setMinimumHeight(380)
-        rtsp_layout = QFormLayout()
-        rtsp_layout.setSpacing(15)
-        rtsp_layout.setContentsMargins(20, 20, 20, 20)
-        
-        # IP
-        ip_input = QLineEdit()
-        ip_input.setPlaceholderText("192.168.1.10")
-        ip_input.setFont(QFont("Segoe UI", 10))
-        ip_input.setMinimumHeight(45)
-        widgets['ip'] = ip_input
-        
-        # Usuario
-        user_input = QLineEdit()
-        user_input.setPlaceholderText("Usuario de Camera Account")
-        user_input.setFont(QFont("Segoe UI", 10))
-        user_input.setMinimumHeight(45)
-        widgets['username'] = user_input
-        
-        # Contraseña
-        pass_input = QLineEdit()
-        pass_input.setPlaceholderText("Contraseña")
-        pass_input.setFont(QFont("Segoe UI", 10))
-        pass_input.setMinimumHeight(45)
-        pass_input.setEchoMode(QLineEdit.Password)
-        widgets['password'] = pass_input
-        
-        # Checkbox mostrar contraseña
-        show_pass = QCheckBox("Mostrar contraseña")
-        show_pass.setFont(QFont("Segoe UI", 9))
-        show_pass.stateChanged.connect(
-            lambda state: pass_input.setEchoMode(
-                QLineEdit.Normal if state == Qt.Checked else QLineEdit.Password
-            )
-        )
-        
-        # Calidad de stream
-        stream_combo = QComboBox()
-        stream_combo.addItems([
-            "Alta Calidad (stream1) - 2304x1296",
-            "Baja Calidad (stream2) - 640x360"
-        ])
-        stream_combo.setFont(QFont("Segoe UI", 10))
-        stream_combo.setMinimumHeight(45)
-        widgets['stream'] = stream_combo
-        
-        rtsp_layout.addRow("🌐 IP:", ip_input)
-        rtsp_layout.addRow("👤 Usuario:", user_input)
-        rtsp_layout.addRow("🔒 Contraseña:", pass_input)
-        rtsp_layout.addRow("", show_pass)
-        rtsp_layout.addRow("📺 Calidad:", stream_combo)
-        
-        rtsp_group.setLayout(rtsp_layout)
+        rtsp_group = RtspFieldsGroup(title="🌐 Conexión de la cámara")
+        widgets['fields'] = rtsp_group
         tab_layout.addWidget(rtsp_group)
         
         # ==========================================
@@ -446,18 +396,13 @@ class MonitoringWindow(QMainWindow):
             for camera_key, config in self.cameras.items():
                 if camera_key in self.camera_widgets:
                     widgets = self.camera_widgets[camera_key]
-                    
-                    widgets['ip'].setText(config.get('ip', ''))
-                    widgets['username'].setText(config.get('username', ''))
-                    widgets['password'].setText(config.get('password', ''))
+
+                    widgets['fields'].set_config(config)
                     widgets['location'].setText(config.get('location', ''))
                     widgets['enabled'].setChecked(config.get('enabled', True))
-                    
-                    if config.get('stream') == 'stream2':
-                        widgets['stream'].setCurrentIndex(1)
-            
+
             logging.info(f"Configuraciones cargadas para {len(self.camera_widgets)} cámara(s)")
-            
+
         except Exception as e:
             logging.error(f"Error al cargar configuraciones: {e}")
     
@@ -518,24 +463,20 @@ class MonitoringWindow(QMainWindow):
             )
     
     def get_camera_config(self, camera_key):
-        """Obtener configuración de una cámara"""
+        """Obtener configuración de una cámara (identificación + conexión RTSP por marca)."""
         if camera_key not in self.camera_widgets:
             return None
-        
+
         widgets = self.camera_widgets[camera_key]
         camera_num = self.get_camera_number(camera_key)
-        stream_idx = widgets['stream'].currentIndex()
-        
-        return {
+
+        config = {
             'name': self.cameras[camera_key].get('name', f'Cámara {camera_num}'),
-            'ip': widgets['ip'].text(),
-            'username': widgets['username'].text(),
-            'password': widgets['password'].text(),
-            'stream': 'stream1' if stream_idx == 0 else 'stream2',
-            'port': 554,
             'location': widgets['location'].text(),
-            'enabled': widgets['enabled'].isChecked()
+            'enabled': widgets['enabled'].isChecked(),
         }
+        config.update(widgets['fields'].get_config())
+        return config
     
     def test_camera(self, camera_key):
         """Probar conexión de una cámara individual"""
@@ -549,17 +490,22 @@ class MonitoringWindow(QMainWindow):
             )
             return
         
-        # Validar campos
-        if not config['ip'] or not config['username'] or not config['password']:
+        # Validar campos (según la marca)
+        brand = config.get('brand', 'tapo')
+        if profiles.brand_uses_custom_path(brand):
+            valid = bool((config.get('path') or '').strip())
+        else:
+            valid = bool(config['ip'] and config['username'] and config['password'])
+        if not valid:
             QMessageBox.warning(
                 self, "Campos Incompletos",
-                f"Complete todos los campos de la cámara {camera_num}."
+                f"Complete los datos de conexión de la cámara {camera_num}."
             )
             return
-        
-        # Construir URL RTSP
-        rtsp_url = f"rtsp://{config['username']}:{config['password']}@{config['ip']}:554/{config['stream']}"
-        
+
+        # Construir URL RTSP según la marca
+        rtsp_url = profiles.build_rtsp_url(config)
+
         QMessageBox.information(
             self, "Probando Conexión",
             f"Conectando a cámara {camera_num}...\nEsto puede tardar unos segundos."
@@ -583,7 +529,7 @@ class MonitoringWindow(QMainWindow):
                         f"¡Conexión exitosa!\n\n"
                         f"Resolución: {width}x{height}\n"
                         f"IP: {config['ip']}\n"
-                        f"Stream: {config['stream']}"
+                        f"Marca: {profiles.brand_label(config.get('brand', 'tapo'))}"
                     )
                 else:
                     QMessageBox.warning(
@@ -619,13 +565,13 @@ class MonitoringWindow(QMainWindow):
                 results.append(f"Cámara {camera_num}: ⚪ Deshabilitada")
                 continue
             
-            if not config['ip'] or not config['username'] or not config['password']:
+            if not self._camera_config_is_complete(config):
                 results.append(f"Cámara {camera_num}: ⚠️ Campos incompletos")
                 continue
-            
+
             # Probar conexión
-            rtsp_url = f"rtsp://{config['username']}:{config['password']}@{config['ip']}:554/{config['stream']}"
-            
+            rtsp_url = profiles.build_rtsp_url(config)
+
             try:
                 os.environ["OPENCV_FFMPEG_CAPTURE_OPTIONS"] = (
                     "rtsp_transport;udp|fflags;nobuffer|flags;low_delay"
@@ -658,6 +604,21 @@ class MonitoringWindow(QMainWindow):
         local, _, domain = text.partition('@')
         return bool(local) and '.' in domain and not domain.startswith('.') and not domain.endswith('.')
 
+    def _camera_config_is_complete(self, config):
+        """Validar que una cámara tenga los datos necesarios según su marca."""
+        if not config.get('location'):
+            return False
+        brand = config.get('brand', 'tapo')
+        if profiles.brand_uses_custom_path(brand):
+            path = (config.get('path') or '').strip()
+            if not path:
+                return False
+            # Si pegó la URL rtsp:// completa, no exige IP/credenciales aparte.
+            if path.lower().startswith('rtsp://'):
+                return True
+            return bool(config.get('ip'))
+        return bool(config.get('ip') and config.get('username') and config.get('password'))
+
     def start_monitoring_system(self):
         """Iniciar sistema de monitoreo multi-cámara"""
         # Validar correo de alertas (solo correo electrónico)
@@ -684,7 +645,7 @@ class MonitoringWindow(QMainWindow):
             camera_num = self.get_camera_number(camera_key)
             
             if config['enabled']:
-                if not config['ip'] or not config['username'] or not config['password'] or not config['location']:
+                if not self._camera_config_is_complete(config):
                     QMessageBox.warning(
                         self, f"Cámara {camera_num} Incompleta",
                         f"Complete todos los campos de la cámara {camera_num}."

--- a/Cliente/App/rtsp_fields.py
+++ b/Cliente/App/rtsp_fields.py
@@ -1,0 +1,214 @@
+# -*- coding: utf-8 -*-
+"""
+rtsp_fields.py - Grupo de campos RTSP reutilizable (marca, IP, puerto, usuario,
+contraseña, canal, calidad y ruta personalizada) con vista previa en vivo de la URL.
+
+Se usa tanto en el gestor de cámaras (AddCameraDialog) como en la ventana de
+monitoreo (tabs por cámara), para que la lógica marca->ruta->preview exista en un
+solo lugar.
+"""
+
+from PyQt5.QtWidgets import (QGroupBox, QLabel, QLineEdit, QComboBox, QCheckBox,
+                             QFormLayout, QHBoxLayout, QWidget)
+from PyQt5.QtCore import Qt
+from PyQt5.QtGui import QFont
+
+from . import rtsp_profiles as profiles
+
+
+class RtspFieldsGroup(QGroupBox):
+    """QGroupBox con todos los campos de conexión RTSP de una cámara."""
+
+    def __init__(self, parent=None, title="🌐 Conexión de la cámara"):
+        super().__init__(title, parent)
+        self.setFont(QFont("Segoe UI", 11, QFont.Bold))
+        self._rows = {}
+        self._build()
+        self._on_brand_changed()  # estado inicial de visibilidad + preview
+
+    # ------------------------------------------------------------------ UI
+    def _build(self):
+        form = QFormLayout()
+        form.setSpacing(12)
+        form.setContentsMargins(18, 18, 18, 18)
+        field_font = QFont("Segoe UI", 10)
+
+        # --- Marca ---
+        self.brand_combo = QComboBox()
+        for _key, label in profiles.BRANDS:
+            self.brand_combo.addItem(label)
+        self.brand_combo.setFont(field_font)
+        self.brand_combo.setMinimumHeight(38)
+        self.brand_combo.currentIndexChanged.connect(self._on_brand_changed)
+        self._add_row(form, 'brand', "📷 Marca/Tipo:", self.brand_combo)
+
+        # --- IP ---
+        self.ip_input = QLineEdit()
+        self.ip_input.setPlaceholderText("192.168.1.64")
+        self.ip_input.setFont(field_font)
+        self.ip_input.setMinimumHeight(38)
+        self.ip_input.textChanged.connect(self._refresh_preview)
+        self._add_row(form, 'ip', "🌐 Dirección IP:", self.ip_input)
+
+        # --- Puerto ---
+        self.port_input = QLineEdit()
+        self.port_input.setText(str(profiles.DEFAULT_PORT))
+        self.port_input.setPlaceholderText("554")
+        self.port_input.setFont(field_font)
+        self.port_input.setMinimumHeight(38)
+        self.port_input.textChanged.connect(self._refresh_preview)
+        self._add_row(form, 'port', "🔌 Puerto:", self.port_input)
+
+        # --- Usuario ---
+        self.user_input = QLineEdit()
+        self.user_input.setPlaceholderText("admin")
+        self.user_input.setFont(field_font)
+        self.user_input.setMinimumHeight(38)
+        self.user_input.textChanged.connect(self._refresh_preview)
+        self._add_row(form, 'username', "👤 Usuario:", self.user_input)
+
+        # --- Contraseña (+ mostrar) ---
+        self.pass_input = QLineEdit()
+        self.pass_input.setPlaceholderText("Contraseña")
+        self.pass_input.setFont(field_font)
+        self.pass_input.setMinimumHeight(38)
+        self.pass_input.setEchoMode(QLineEdit.Password)
+        self.pass_input.textChanged.connect(self._refresh_preview)
+        show_pass = QCheckBox("Mostrar")
+        show_pass.setFont(QFont("Segoe UI", 9))
+        show_pass.stateChanged.connect(
+            lambda state: self.pass_input.setEchoMode(
+                QLineEdit.Normal if state == Qt.Checked else QLineEdit.Password
+            )
+        )
+        pass_container = QWidget()
+        pass_layout = QHBoxLayout(pass_container)
+        pass_layout.setContentsMargins(0, 0, 0, 0)
+        pass_layout.addWidget(self.pass_input)
+        pass_layout.addWidget(show_pass)
+        self._add_row(form, 'password', "🔒 Contraseña:", pass_container)
+
+        # --- Canal (solo marcas con NVR) ---
+        self.channel_input = QLineEdit()
+        self.channel_input.setText("1")
+        self.channel_input.setPlaceholderText("1")
+        self.channel_input.setFont(field_font)
+        self.channel_input.setMinimumHeight(38)
+        self.channel_input.textChanged.connect(self._refresh_preview)
+        self._add_row(form, 'channel', "🔢 Canal (NVR):", self.channel_input)
+
+        # --- Calidad ---
+        self.quality_combo = QComboBox()
+        for _key, label in profiles.QUALITIES:
+            self.quality_combo.addItem(label)
+        self.quality_combo.setFont(field_font)
+        self.quality_combo.setMinimumHeight(38)
+        self.quality_combo.currentIndexChanged.connect(self._refresh_preview)
+        self._add_row(form, 'quality', "📺 Calidad:", self.quality_combo)
+
+        # --- Ruta personalizada (solo marca genérica/otra) ---
+        self.path_input = QLineEdit()
+        self.path_input.setPlaceholderText("Streaming/Channels/101  (o pega la URL rtsp:// completa)")
+        self.path_input.setFont(field_font)
+        self.path_input.setMinimumHeight(38)
+        self.path_input.textChanged.connect(self._refresh_preview)
+        self._add_row(form, 'path', "🛣️ Ruta RTSP:", self.path_input)
+
+        # --- Vista previa de la URL ---
+        self.preview_label = QLabel("rtsp://…")
+        self.preview_label.setFont(QFont("Consolas", 9))
+        self.preview_label.setWordWrap(True)
+        self.preview_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
+        self.preview_label.setStyleSheet(
+            "color: #2c3e50; background-color: #ecf0f1; border: 1px solid #bdc3c7;"
+            " border-radius: 4px; padding: 6px;"
+        )
+        self._add_row(form, 'preview', "🔗 URL resultante:", self.preview_label)
+
+        self.setLayout(form)
+
+    def _add_row(self, form, name, label_text, field):
+        label = QLabel(label_text)
+        label.setFont(QFont("Segoe UI", 10))
+        form.addRow(label, field)
+        self._rows[name] = (label, field)
+
+    def _set_row_visible(self, name, visible):
+        label, field = self._rows[name]
+        label.setVisible(visible)
+        field.setVisible(visible)
+
+    # -------------------------------------------------------------- estado
+    def current_brand(self):
+        idx = self.brand_combo.currentIndex()
+        if 0 <= idx < len(profiles.BRANDS):
+            return profiles.BRANDS[idx][0]
+        return profiles.DEFAULT_BRAND
+
+    def _current_quality(self):
+        idx = self.quality_combo.currentIndex()
+        if 0 <= idx < len(profiles.QUALITIES):
+            return profiles.QUALITIES[idx][0]
+        return 'main'
+
+    def _on_brand_changed(self):
+        brand = self.current_brand()
+        self._set_row_visible('channel', profiles.brand_needs_channel(brand))
+        self._set_row_visible('path', profiles.brand_uses_custom_path(brand))
+        self._refresh_preview()
+
+    def _refresh_preview(self):
+        try:
+            self.preview_label.setText(profiles.masked_rtsp_url(self.get_config()))
+        except Exception:
+            self.preview_label.setText("rtsp://…")
+
+    # ----------------------------------------------------------- get/set
+    def get_config(self):
+        """Devolver la config (dict) representada por los campos."""
+        try:
+            port = int(self.port_input.text().strip())
+        except (ValueError, AttributeError):
+            port = profiles.DEFAULT_PORT
+        try:
+            channel = int(self.channel_input.text().strip())
+        except (ValueError, AttributeError):
+            channel = 1
+
+        quality = self._current_quality()
+        return {
+            'brand': self.current_brand(),
+            'ip': self.ip_input.text().strip(),
+            'port': port,
+            'username': self.user_input.text().strip(),
+            'password': self.pass_input.text(),
+            'channel': channel,
+            'quality': quality,
+            'stream': profiles.quality_to_stream(quality),  # compat legacy
+            'path': self.path_input.text().strip(),
+        }
+
+    def set_config(self, cfg):
+        """Cargar valores desde una config existente (con compat de formato viejo)."""
+        cfg = cfg or {}
+
+        # Marca
+        brand = (cfg.get('brand') or profiles.DEFAULT_BRAND).lower()
+        brand_idx = next((i for i, (k, _l) in enumerate(profiles.BRANDS) if k == brand), 0)
+        self.brand_combo.setCurrentIndex(brand_idx)
+
+        self.ip_input.setText(str(cfg.get('ip', '') or ''))
+        self.port_input.setText(str(cfg.get('port', profiles.DEFAULT_PORT) or profiles.DEFAULT_PORT))
+        self.user_input.setText(str(cfg.get('username', '') or ''))
+        self.pass_input.setText(str(cfg.get('password', '') or ''))
+        self.channel_input.setText(str(cfg.get('channel', 1) or 1))
+        self.path_input.setText(str(cfg.get('path', '') or ''))
+
+        quality = profiles.normalize_quality(cfg)
+        self.quality_combo.setCurrentIndex(1 if quality == 'sub' else 0)
+
+        self._on_brand_changed()
+
+    def rtsp_url(self):
+        """URL RTSP completa (con contraseña real) para probar/conectar."""
+        return profiles.build_rtsp_url(self.get_config())

--- a/Cliente/App/rtsp_profiles.py
+++ b/Cliente/App/rtsp_profiles.py
@@ -1,0 +1,145 @@
+# -*- coding: utf-8 -*-
+"""
+rtsp_profiles.py - Perfiles RTSP por marca de cámara (fuente única de verdad).
+
+Permite que el sistema funcione con CUALQUIER cámara:
+- Marcas con plantilla automática: Tapo, Hikvision, Dahua, Reolink.
+- "Genérica / Otra": el usuario escribe la ruta RTSP a mano (o pega la URL completa).
+
+Todo el resto del código (formularios y detección) debe usar build_rtsp_url()
+para no repetir el formato en varios lugares.
+"""
+
+from urllib.parse import quote
+
+# (clave, etiqueta para mostrar). El orden es el que se ve en el combo.
+BRANDS = [
+    ('tapo', 'Tapo (TP-Link)'),
+    ('hikvision', 'Hikvision'),
+    ('dahua', 'Dahua'),
+    ('reolink', 'Reolink'),
+    ('custom', 'Genérica / Otra (ruta manual)'),
+]
+
+# Calidad de stream: clave canónica -> etiqueta
+QUALITIES = [
+    ('main', 'Principal (alta calidad)'),
+    ('sub', 'Secundaria (baja calidad)'),
+]
+
+# Marcas que usan número de canal (útil para NVR/DVR con varias cámaras).
+_NEEDS_CHANNEL = {'hikvision', 'dahua', 'reolink'}
+# Marcas que muestran un campo de ruta RTSP manual.
+_USES_CUSTOM_PATH = {'custom'}
+
+DEFAULT_BRAND = 'tapo'
+DEFAULT_PORT = 554
+
+
+def brand_label(brand):
+    """Etiqueta legible de una marca."""
+    for key, label in BRANDS:
+        if key == brand:
+            return label
+    return brand or DEFAULT_BRAND
+
+
+def brand_needs_channel(brand):
+    """True si la marca usa número de canal (NVR/DVR)."""
+    return (brand or '').lower() in _NEEDS_CHANNEL
+
+
+def brand_uses_custom_path(brand):
+    """True si la marca usa una ruta RTSP escrita a mano."""
+    return (brand or '').lower() in _USES_CUSTOM_PATH
+
+
+def normalize_quality(cfg):
+    """
+    Devolver 'main' o 'sub' a partir de la config.
+    Compatibilidad: cameras.json viejos solo tienen 'stream': 'stream1'/'stream2'.
+    """
+    quality = cfg.get('quality')
+    if quality in ('main', 'sub'):
+        return quality
+    return 'sub' if str(cfg.get('stream', 'stream1')) == 'stream2' else 'main'
+
+
+def quality_to_stream(quality):
+    """Mapear 'main'/'sub' al campo legacy 'stream1'/'stream2'."""
+    return 'stream2' if quality == 'sub' else 'stream1'
+
+
+def build_path(brand, channel, quality):
+    """
+    Construir SOLO la ruta (lo que va después de :puerto/) según la marca.
+    quality: 'main' | 'sub'. channel: entero (canal del NVR; 1 para IP suelta).
+    """
+    brand = (brand or DEFAULT_BRAND).lower()
+    try:
+        ch = int(channel)
+    except (ValueError, TypeError):
+        ch = 1
+    if ch < 1:
+        ch = 1
+
+    if brand == 'hikvision':
+        # 101 = canal 1 principal, 102 = canal 1 secundario, 201 = canal 2...
+        sub = '01' if quality == 'main' else '02'
+        return f"Streaming/Channels/{ch}{sub}"
+    if brand == 'dahua':
+        subtype = '0' if quality == 'main' else '1'
+        return f"cam/realmonitor?channel={ch}&subtype={subtype}"
+    if brand == 'reolink':
+        suffix = 'main' if quality == 'main' else 'sub'
+        return f"h264Preview_{ch:02d}_{suffix}"
+    # tapo y fallback
+    return 'stream1' if quality == 'main' else 'stream2'
+
+
+def build_rtsp_url(cfg):
+    """
+    Construir la URL RTSP completa a partir de una config de cámara (dict).
+
+    Maneja:
+    - URL-encode de usuario y contraseña (Hikvision/Dahua suelen tener símbolos).
+    - Marca 'custom': usa la ruta escrita a mano, o la URL completa si empieza con rtsp://.
+    - Compatibilidad con cameras.json antiguos (sin 'brand', solo 'stream').
+
+    Nunca lanza excepción: ante cualquier dato faltante usa valores por defecto.
+    """
+    try:
+        brand = (cfg.get('brand') or DEFAULT_BRAND).lower()
+        user = quote(str(cfg.get('username', '') or ''), safe='')
+        pwd = quote(str(cfg.get('password', '') or ''), safe='')
+        ip = str(cfg.get('ip', '') or '').strip()
+        port = cfg.get('port', DEFAULT_PORT) or DEFAULT_PORT
+        quality = normalize_quality(cfg)
+
+        if brand_uses_custom_path(brand):
+            raw = str(cfg.get('path', '') or '').strip()
+            if raw.lower().startswith('rtsp://'):
+                # El usuario pegó la URL completa: usarla tal cual.
+                return raw
+            path = raw.lstrip('/')
+            return f"rtsp://{user}:{pwd}@{ip}:{port}/{path}"
+
+        path = build_path(brand, cfg.get('channel', 1), quality)
+        return f"rtsp://{user}:{pwd}@{ip}:{port}/{path}"
+    except Exception:
+        # Último recurso: formato Tapo clásico, sin encode.
+        return (
+            f"rtsp://{cfg.get('username', '')}:{cfg.get('password', '')}"
+            f"@{cfg.get('ip', '')}:{cfg.get('port', DEFAULT_PORT)}/"
+            f"{cfg.get('stream', 'stream1')}"
+        )
+
+
+def masked_rtsp_url(cfg):
+    """Como build_rtsp_url pero ocultando la contraseña (para mostrar en pantalla)."""
+    url = build_rtsp_url(cfg)
+    pwd = str(cfg.get('password', '') or '')
+    if pwd:
+        encoded = quote(pwd, safe='')
+        url = url.replace(':' + encoded + '@', ':****@').replace(':' + pwd + '@', ':****@')
+    return url

--- a/Cliente/cameras.json
+++ b/Cliente/cameras.json
@@ -18,5 +18,35 @@
         "stream": "stream1",
         "port": 554,
         "enabled": true
+    },
+    "camera_3": {
+        "name": "Camara tres ",
+        "ip": "192.168.0.11",
+        "username": "admin",
+        "password": "admin",
+        "location": "Entrada Principal",
+        "stream": "stream2",
+        "port": 554,
+        "enabled": true
+    },
+    "camera_4": {
+        "name": "camara cuatro",
+        "ip": "192.168.1.10",
+        "username": "admin",
+        "password": "admin",
+        "location": "Entrada Sur",
+        "stream": "stream1",
+        "port": 554,
+        "enabled": true
+    },
+    "camera_5": {
+        "name": "Camara 5",
+        "ip": "192.168.1.15",
+        "username": "admin",
+        "password": "admin",
+        "location": "Entrada",
+        "stream": "stream1",
+        "port": 554,
+        "enabled": true
     }
 }

--- a/Cliente/main.py
+++ b/Cliente/main.py
@@ -2,12 +2,28 @@
 import sys
 import os
 import logging
+import subprocess
+
+# En Windows, evitar que los subprocesos (p.ej. nvidia-smi, que GPUtil invoca
+# cada pocos segundos durante la deteccion) abran ventanas de consola que parpadean.
+# Se envuelve subprocess.Popen para forzar CREATE_NO_WINDOW en toda la app.
+if sys.platform.startswith('win'):
+    _CREATE_NO_WINDOW = getattr(subprocess, 'CREATE_NO_WINDOW', 0x08000000)
+    _orig_popen_init = subprocess.Popen.__init__
+
+    def _popen_no_window(self, *args, **kwargs):
+        kwargs['creationflags'] = kwargs.get('creationflags', 0) | _CREATE_NO_WINDOW
+        _orig_popen_init(self, *args, **kwargs)
+
+    subprocess.Popen.__init__ = _popen_no_window
+
 from PyQt5.QtWidgets import QApplication
 from PyQt5.QtCore import QObject, QSharedMemory
 from App.loginWindowClass import LoginWindow
 from App.monitoringWindowClass import MonitoringWindow
 from App.detectionWindowDual import DetectionWindowDual
 from App.detection_tapo import DetectionTapo
+from App.inference_engine import InferenceEngine
 from App.cameras_config import GLOBAL_CONFIG
 
 # Configurar codificación UTF-8 para la aplicación
@@ -88,6 +104,7 @@ class MainApplication(QObject):
         # Estado de la aplicación
         self.current_window = None
         self.detection_threads = {}  # Almacenar threads de detección activos
+        self.engine = None  # Motor de inferencia COMPARTIDO (1 modelo para todas las cámaras)
         self.is_logged_in = False
         self.current_token = None
         
@@ -165,10 +182,33 @@ class MainApplication(QObject):
             
             # Cerrar ventana de configuración
             self.close_current_window()
-            
+
+            # Crear UN motor de inferencia COMPARTIDO (carga el modelo UNA sola vez
+            # para todas las cámaras, en vez de una copia por cámara).
+            self.engine = InferenceEngine(
+                GLOBAL_CONFIG['model_path'],
+                conf=GLOBAL_CONFIG.get('confidence_threshold', 0.5),
+                iou=0.45,
+                max_det=GLOBAL_CONFIG.get('max_detections', 10),
+                num_workers=GLOBAL_CONFIG.get('inference_workers', 1),
+            )
+            try:
+                self.engine.start()  # ÚNICA carga del modelo
+            except Exception as e:
+                logging.exception(f"Error al cargar el modelo de inferencia: {e}")
+                from PyQt5.QtWidgets import QMessageBox
+                QMessageBox.critical(
+                    None, "Error de Modelo",
+                    f"No se pudo cargar el modelo de detección:\n\n{str(e)}\n\n"
+                    f"Revise el archivo de log para más detalles."
+                )
+                self._teardown_engine()
+                self.show_monitoring(self.current_token)
+                return
+
             # Crear threads de detección para cada cámara habilitada
             self.detection_threads = {}
-            
+
             for cam_num, config in cameras.items():
                 logging.info(f"")
                 logging.info(f"Configurando Cámara {cam_num}:")
@@ -176,17 +216,18 @@ class MainApplication(QObject):
                 logging.info(f"  Usuario: {config['username']}")
                 logging.info(f"  Stream: {config['stream']}")
                 logging.info(f"  Ubicación: {config['location']}")
-                
-                # Crear instancia de DetectionTapo
+
+                # Crear instancia de DetectionTapo (sin modelo propio: usa el engine compartido)
                 detection = DetectionTapo(
                     model_path=GLOBAL_CONFIG['model_path'],
                     token=token,
                     location=config['location'],
                     receiver=receiver,
                     camera_config=config,
-                    camera_id=cam_num
+                    camera_id=cam_num,
+                    engine=self.engine
                 )
-                
+
                 self.detection_threads[cam_num] = detection
                 logging.info(f"  Thread de detección creado para Cámara {cam_num}")
             
@@ -205,6 +246,17 @@ class MainApplication(QObject):
             
         except Exception as e:
             logging.exception(f"Error crítico al iniciar detección multi-cámara: {e}")
+            # Limpiar cámaras ya creadas y el engine para NO dejar fugas
+            # (modelo en RAM/VRAM + worker huérfano) si falla a mitad del arranque.
+            for detection in self.detection_threads.values():
+                try:
+                    detection.stop()
+                    detection.wait(3000)
+                except Exception:
+                    pass
+            self.detection_threads.clear()
+            self._teardown_engine()
+
             from PyQt5.QtWidgets import QMessageBox
             QMessageBox.critical(
                 None, "Error Crítico",
@@ -214,17 +266,35 @@ class MainApplication(QObject):
             # Volver a monitoring si hay error
             self.show_monitoring(self.current_token)
 
+    def _teardown_engine(self):
+        """Detener y liberar el motor de inferencia compartido de forma segura.
+
+        Centraliza el apagado para que NINGÚN camino (cierre normal, logout o
+        error a mitad del arranque) deje el engine vivo y huérfano (modelo en
+        RAM/VRAM + worker daemon colgado).
+        """
+        if self.engine:
+            try:
+                self.engine.stop()
+            except Exception as e:
+                logging.error(f"Error al detener el motor de inferencia: {e}")
+            self.engine = None
+
     def on_detection_closed(self):
         """Manejar cierre de ventana de detección"""
         logging.info("Detección cerrada - Deteniendo threads")
         
-        # Detener todos los threads de detección
+        # Detener todos los threads de detección PRIMERO
         for cam_num, detection in self.detection_threads.items():
             logging.info(f"Deteniendo thread de cámara {cam_num}")
             detection.stop()
             detection.wait(5000)  # Esperar máximo 5 segundos
-        
+
         self.detection_threads.clear()
+
+        # Detener el motor de inferencia DESPUÉS de las cámaras (apagado ordenado)
+        self._teardown_engine()
+
         logging.info("Todos los threads detenidos - Volviendo a configuración")
         self.show_monitoring(self.current_token)
 
@@ -236,8 +306,12 @@ class MainApplication(QObject):
         if self.detection_threads:
             for detection in self.detection_threads.values():
                 detection.stop()
+                detection.wait(5000)
             self.detection_threads.clear()
-        
+
+        # Detener el motor de inferencia compartido
+        self._teardown_engine()
+
         self.is_logged_in = False
         self.current_token = None
         self.close_current_window()

--- a/Cliente/weapon_detection_prod.spec
+++ b/Cliente/weapon_detection_prod.spec
@@ -1,0 +1,113 @@
+# -*- mode: python ; coding: utf-8 -*-
+# Weapon Detection System v2.0 - PyInstaller Spec (PRODUCCION / camaras Tapo RTSP)
+#
+# Diferencias clave frente a weapon_detection.spec original:
+#   1) sys.setrecursionlimit(...) -> evita RecursionError de torch/ultralytics al analizar.
+#   2) Se copian TODAS las DLLs de Intel MKL (+ libiomp5md) a la raiz del dist.
+#      Sin esto, "import torch" crashea con 0xc06d007e (DLL no encontrada) porque
+#      torch_cpu.dll depende de mkl_core/mkl_avx*/mkl_vml_* que PyInstaller no empaqueta.
+
+import sys
+import os
+import glob
+
+# (1) Fix RecursionError de torch/ultralytics durante el Analysis
+sys.setrecursionlimit(sys.getrecursionlimit() * 5)
+
+block_cipher = None
+app_name = "WeaponDetectionSystem"
+
+# Datos adicionales (van a la raiz del dist en modo onedir)
+added_files = [
+    ('UI/*.ui', 'UI'),
+    ('model/last.pt', 'model'),
+    ('Styles/*.py', 'Styles'),
+    ('requirements*.txt', '.'),
+    ('config/settings.ini', '.'),
+]
+
+# (2) CRITICO: recolectar el set completo de DLLs de Intel MKL + OpenMP
+#     desde <Python>\Library\bin y copiarlas a la raiz del dist ('.').
+_py_dir = os.path.dirname(sys.executable)
+_mkl_dir = os.path.join(_py_dir, 'Library', 'bin')
+mkl_binaries = []
+if os.path.isdir(_mkl_dir):
+    for _dll in glob.glob(os.path.join(_mkl_dir, 'mkl_*.dll')):
+        mkl_binaries.append((_dll, '.'))
+    for _extra in ('libiomp5md.dll', 'libiompstubs5md.dll'):
+        _p = os.path.join(_mkl_dir, _extra)
+        if os.path.exists(_p):
+            mkl_binaries.append((_p, '.'))
+print("[spec] MKL/OpenMP DLLs incluidas:", len(mkl_binaries), "desde", _mkl_dir)
+
+# Icono opcional
+icon_path = 'UI/icon.ico'
+if not os.path.exists(icon_path):
+    icon_path = None
+
+hiddenimports = [
+    # PyQt5
+    'PyQt5.QtCore', 'PyQt5.QtGui', 'PyQt5.QtWidgets', 'PyQt5.uic', 'PyQt5.sip',
+    # Vision
+    'cv2', 'numpy', 'PIL', 'PIL.Image',
+    # YOLO / ultralytics
+    'ultralytics', 'ultralytics.models', 'ultralytics.models.yolo',
+    'ultralytics.models.yolo.detect', 'ultralytics.nn', 'ultralytics.nn.modules',
+    'ultralytics.utils', 'ultralytics.data',
+    # PyTorch
+    'torch', 'torch.nn', 'torch.nn.functional', 'torchvision', 'torchvision.transforms',
+    # Matplotlib (lo usa ultralytics)
+    'matplotlib', 'matplotlib.pyplot', 'matplotlib.backends', 'matplotlib.backends.backend_agg',
+    # Otras
+    'requests', 'psutil', 'GPUtil', 'logging', 'threading', 'queue', 'time', 'json',
+    'os', 'sys', 're', 'webbrowser', 'datetime', 'codecs', 'locale',
+    'yaml', 'tqdm', 'scipy', 'pandas', 'seaborn',
+]
+
+a = Analysis(
+    ['main.py'],
+    pathex=['.'],
+    binaries=mkl_binaries,
+    datas=added_files,
+    hiddenimports=hiddenimports,
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name=app_name,
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=False,            # UPX puede corromper DLLs de MKL/torch -> mejor sin comprimir
+    console=False,        # App con ventana (sin consola)
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+    icon=icon_path,
+)
+
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=False,
+    upx_exclude=[],
+    name=app_name,
+)

--- a/Server/alertuploadREST/views.py
+++ b/Server/alertuploadREST/views.py
@@ -8,7 +8,6 @@ from rest_framework.exceptions import ValidationError
 
 from django.http import JsonResponse
 
-from twilio.rest import Client
 from threading import Thread
 import re
 import os
@@ -29,7 +28,7 @@ def postAlert(request):
     if serializer.is_valid():
         serializer.save()
         print(f"Alerta guardada exitosamente. Datos: {serializer.data}")
-        identify_email_sms(serializer)
+        send_email_alert(serializer)
         # 🔔 Notificación Web Push al dueño de la alerta (en segundo plano)
         send_web_push(serializer.instance)
 
@@ -48,22 +47,27 @@ def send_web_push(alert_instance):
     except Exception as e:
         print(f"Error al enviar notificación web push: {e}")
 
-# Identifica si el usuario proporcionó un correo electrónico o un número de teléfono
-def identify_email_sms(serializer):
+# Validación de correo electrónico (el cliente solo admite correo).
+EMAIL_REGEX = re.compile(r'^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$')
+
+
+def is_valid_email(value):
+    return bool(EMAIL_REGEX.match((value or '').strip()))
+
+
+# Envía la alerta por correo electrónico vía SendGrid.
+def send_email_alert(serializer):
     receiver = serializer.data['alertReceiver']
     image_path = serializer.data.get('image', 'Sin ruta de imagen')
-    
+
     print(f"Procesando alerta para el receptor: {receiver}")
     print(f"Ruta de imagen: {image_path}")
 
-    if(re.search('r^[a-z0-9]+[\._]?[a-z0-9]+[@]\w+[.]\w{2,3}$', receiver)):  
+    if is_valid_email(receiver):
         print("Correo electrónico válido - Enviando correo vía SendGrid...")
         send_enhanced_email(serializer)
-    elif re.compile("[+593][0-9]{10}").match(receiver):
-        print("Número de teléfono válido - Enviando SMS...")
-        send_sms(serializer)
     else:
-        print(f"Correo electrónico o número de teléfono inválido: {receiver}")
+        print(f"Correo electrónico inválido: {receiver}")
 
 @start_new_thread
 def send_enhanced_email(serializer):
@@ -379,40 +383,6 @@ def create_html_email(alert_data):
 </html>
 """
     return html_template
-
-# Envía SMS
-@start_new_thread
-def send_sms(serializer):
-    try:
-        print("Iniciando proceso de envío de SMS...")
-        alert_data = extract_alert_data(serializer)
-        
-        # Mensaje SMS mejorado pero conciso
-        sms_message = f"""🚨 ALERTA SEGURIDAD
-Arma detectada - {alert_data['timestamp'].strftime('%d/%m %H:%M')}
-Ubicación: {alert_data['location']}
-Ver: {alert_data['alert_url']}
-ID: {alert_data['alert_id']}"""
-        
-        client = Client(settings.TWILIO_ACCOUNT_SID, settings.TWILIO_AUTH_TOKEN)
-        
-        print(f"Detalles del SMS:")
-        print(f"  Mensaje: {sms_message}")
-        print(f"  De: {settings.TWILIO_NUMBER}")
-        print(f"  Para: {serializer.data['alertReceiver']}")
-
-        message = client.messages.create(
-            body=sms_message,
-            from_=settings.TWILIO_NUMBER,
-            to=serializer.data['alertReceiver']
-        )
-        
-        print(f"¡SMS enviado exitosamente! SID: {message.sid}")
-        
-    except Exception as e:
-        print(f"Error al enviar SMS: {e}")
-        import traceback
-        print(f"Rastreo completo: {traceback.format_exc()}")
 
 def generate_alert_url(image_path):
     try:

--- a/Server/build.sh
+++ b/Server/build.sh
@@ -1,12 +1,17 @@
 #!/usr/bin/env bash
-# Render build script - Weapon Detection System (Server)
-# Se ejecuta en cada deploy dentro de la red de Render, donde la BD sí conecta.
+# Render build script - Weapon Detection System
+# Se ejecuta en cada deploy dentro de la red de Render, donde la BD si conecta.
+# Invocar como Build Command:  bash Server/build.sh
 set -o errexit
 
-pip install -r requirements.txt
+# Entra a la carpeta Server sin importar desde donde se invoque
+cd "$(dirname "$0")"
 
-# Crea las tablas en la base de datos PostgreSQL de Render (auth_user, etc.)
-python manage.py migrate --no-input
+# --only-binary=pillow evita compilar Pillow desde fuente en Render
+pip install --only-binary=pillow -r requirements.txt
 
-# Archivos estáticos
-python manage.py collectstatic --no-input
+# Crea las tablas en la BD PostgreSQL de Render (auth_user, etc.)
+python manage.py migrate --noinput
+
+# Archivos estaticos
+python manage.py collectstatic --noinput

--- a/Server/docs/NOTIFICACIONES_PUSH_Y_SESIONES.md
+++ b/Server/docs/NOTIFICACIONES_PUSH_Y_SESIONES.md
@@ -21,7 +21,7 @@ Este documento describe dos cambios en el servidor Django:
 - Las suscripciones del navegador se guardan en el modelo `PushSubscription`,
   ligadas al usuario de la sesión web.
 - El envío ocurre en el flujo de subida de alertas (`POST /api/images/`), en un
-  hilo en segundo plano, junto al email/SMS ya existentes.
+  hilo en segundo plano, junto al correo (SendGrid) ya existente.
 
 ### Componentes
 | Componente | Ruta |
@@ -51,8 +51,8 @@ VAPID_PUBLIC_KEY=<clave_publica_base64url>
 VAPID_PRIVATE_KEY=<clave_privada_base64url>
 VAPID_ADMIN_EMAIL=mailto:tu-correo@dominio.com
 ```
-> Si `VAPID_*` está vacío, el envío de push se omite con un *warning*; el resto del
-> flujo de alertas (email/SMS) sigue funcionando.
+> Si `VAPID_*` está vacío, el envío de push se omite con un *warning*; el envío de
+> alertas por correo (SendGrid) sigue funcionando.
 
 ### Migración
 Se añade la tabla `PushSubscription`:

--- a/Server/requirements.txt
+++ b/Server/requirements.txt
@@ -23,9 +23,6 @@ django-storages==1.14.4
 sendgrid==6.11.0
 django-sendgrid-v5==1.2.3
 
-# SMS - Twilio
-twilio==9.3.2
-
 # Server
 gunicorn==22.0.0
 whitenoise==6.7.0

--- a/Server/webdev/settings.py
+++ b/Server/webdev/settings.py
@@ -172,11 +172,6 @@ STATICFILES_DIRS =[
 ]
 MEDIA_ROOT = 'static/images'
 
-# Twilio configuration
-TWILIO_ACCOUNT_SID = os.environ['TWILIO_ACCOUNT_SID']
-TWILIO_AUTH_TOKEN = os.environ['TWILIO_AUTH_TOKEN']
-TWILIO_NUMBER = os.environ['TWILIO_NUMBER'] 
-
 # ==========================================
 # ✅ SENDGRID EMAIL CONFIGURATION (NUEVO)
 # ==========================================


### PR DESCRIPTION
## Resumen

Optimización de **memoria** del cliente de detección. Hasta ahora cada cámara (`DetectionTapo`) cargaba su **propia** copia del modelo YOLO: con N cámaras había N modelos en RAM/VRAM y N inferencias compitiendo, lo que congelaba la UI y saturaba la memoria. Este PR refactoriza el cliente a un **motor de inferencia compartido**: **un solo modelo** para todas las cámaras. De paso se añade soporte para **cámaras de cualquier marca** (no solo Tapo).

**Impacto medido:** 5 modelos ≈ 1728 MB vs 1 compartido ≈ 884 MB → **~640–840 MB ahorrados**. Inferencia ~55 ms en caliente (GPU). El monitoreo no se reduce: cada cámara sigue recibiendo *siempre* sus propios resultados (enrutados por `camera_id`); lo único que se comparte es el modelo.

## Cambios

### 1. Motor de inferencia compartido — `App/inference_engine.py` (NUEVO)
- `InferenceEngine`: carga el modelo **una sola vez** (`+fuse`, detección GPU/CPU una vez) y lanza worker(s).
- Cola central thread-safe: `submit(camera_id, frame)` encola solo el id y guarda el último frame por cámara (descarta los viejos → sin backlog). Dedup con `_pending` + `_inflight`: a lo sumo **1 trabajo en vuelo por cámara**, seguro incluso con `num_workers > 1`.
- `register/unregister(camera_id, callback)`: enruta cada resultado a su cámara.
- Instrumenta tiempos por cámara (log + `inference_metrics.csv` + `get_metrics_summary()`) para documentar el rendimiento real.
- `App/cameras_config.py`: nuevo `inference_workers` (default 1; subir solo si la GPU lo permite).
- `main.py`: crea/arranca **un** engine antes del loop y lo pasa a cada `DetectionTapo`. `_teardown_engine()` centraliza el apagado (cierre normal, logout y error a mitad del arranque) para no dejar el modelo huérfano en RAM/VRAM. Apaga las cámaras **antes** que el engine.
- `App/detection_tapo.py`: ya **no** carga modelo ni tiene hilo de análisis; solo captura + video en vivo y hace `engine.submit`. Nuevo `on_inference_result` (lo llama el worker) que emite `weaponDetected` + `saveDetection` rate-limitado. **Las señales no cambian** → la ventana de detección queda intacta.

### 2. Soporte multi-marca RTSP — `App/rtsp_profiles.py` + `App/rtsp_fields.py` (NUEVOS)
- El cliente ahora funciona con **cualquier cámara**: Tapo, Hikvision, Dahua, Reolink o "Genérica/Otra" (ruta RTSP manual o URL completa pegada).
- `rtsp_profiles.build_rtsp_url()` es la **fuente única** de la URL (URL-encode de usuario/clave, canal NVR, calidad main/sub), con compatibilidad con los `cameras.json` antiguos (solo `stream`).
- `RtspFieldsGroup`: grupo de campos reutilizable con **vista previa en vivo** de la URL, usado tanto en el gestor de cámaras (`cameraManagerWindow.py`) como en monitoreo (`monitoringWindowClass.py`).

### 3. Otros
- `main.py`: en Windows envuelve `subprocess.Popen` con `CREATE_NO_WINDOW` para que `nvidia-smi` (lo invoca GPUtil durante la detección) no abra consolas que parpadean.
- `Server/build.sh`: `cd` a `Server`, `pip --only-binary=pillow` (evita compilar Pillow en Render) y `--noinput` en `migrate`/`collectstatic`.
- `weapon_detection_prod.spec`: spec de PyInstaller para el build de **producción** (RTSP/Tapo multi-cámara), con los fixes baked-in (`setrecursionlimit` + copia de DLLs de Intel MKL/OpenMP a la raíz del dist, sin lo cual `import torch` crashea con `0xc06d007e`). Análogo al `weapon_detection.spec` ya versionado.

## Verificación
- Carga del modelo **1 sola vez**; enrutado garantizado (ninguna cámara sin resultados); apagado limpio.
- Con `num_workers=3`, ningún par de workers procesa la misma cámara (test de la condición de carrera).
- Revisión adversarial previa: 2 bugs encontrados y corregidos (carrera con `num_workers>1`, fuga del engine al fallar el arranque).

## Notas
- **Limitación inherente:** la decodificación RTSP sigue siendo por cámara (1 hilo de captura c/u); este refactor comparte el *modelo*, no elimina el costo de decodificar N streams.
- El entregable empaquetado (`.exe` de producción ~3 GB) se genera con `weapon_detection_prod.spec` y se distribuye aparte; **no** va al repositorio (`dist/`, `*.zip`, `*.rar` están en `.gitignore`).
