### PR TITLE
Soporte webcam local + fixes de inferencia CPU y correo por Brevo API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ share/python-wheels/
 # Archivos grandes a ignorar específicamente
 Cliente/dist.rar
 Cliente/model/last.pt
+docs/
+Cliente/detections
+Cliente/inference_metrics.csv
 *.pt
 *.pth
 *.h5

--- a/Cliente/App/detection_tapo.py
+++ b/Cliente/App/detection_tapo.py
@@ -51,6 +51,10 @@ class DetectionTapo(QThread):
 
         # Configuración de cámara
         self.camera_config = camera_config
+        # Fuente local (webcam USB / laptop) vs cámara IP RTSP
+        from .rtsp_profiles import is_local_source, local_device_index
+        self.is_local = is_local_source(camera_config)
+        self.local_index = local_device_index(camera_config)
         self.rtsp_url = self._build_rtsp_url()
 
         # Control de ejecución
@@ -155,9 +159,45 @@ class DetectionTapo(QThread):
         
         self.cleanup()
 
+    def _initialize_local_camera(self):
+        """Inicializar una webcam local (USB / cámara de la laptop) por índice."""
+        try:
+            logging.info(f"[Cámara {self.camera_id}] Abriendo webcam local (índice {self.local_index})...")
+
+            # En Windows, DirectShow abre la webcam mucho más rápido y estable.
+            if sys.platform.startswith('win'):
+                self.cap = cv2.VideoCapture(self.local_index, cv2.CAP_DSHOW)
+            else:
+                self.cap = cv2.VideoCapture(self.local_index)
+
+            if self.cap.isOpened():
+                self.cap.set(cv2.CAP_PROP_BUFFERSIZE, 1)
+                width = int(self.cap.get(cv2.CAP_PROP_FRAME_WIDTH))
+                height = int(self.cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+                logging.info(f"[Cámara {self.camera_id}] ✅ Webcam local conectada - {width}x{height}")
+                self.statusUpdate.emit(f"[Cámara {self.camera_id}] Webcam local conectada")
+                return True
+
+            error_msg = f"[Cámara {self.camera_id}] ❌ No se pudo abrir la webcam local (índice {self.local_index})"
+            self.error.emit(error_msg)
+            logging.error(error_msg)
+            self.running = False
+            return False
+
+        except Exception as e:
+            error_msg = f"[Cámara {self.camera_id}] Error al abrir webcam local: {str(e)}"
+            self.error.emit(error_msg)
+            logging.error(error_msg)
+            self.running = False
+            return False
+
     def _initialize_rtsp_camera_optimized(self):
         """Inicializar cámara RTSP con MÁXIMA OPTIMIZACIÓN"""
         try:
+            # Fuente local (webcam USB / laptop): abrir por índice, sin FFmpeg/RTSP.
+            if self.is_local:
+                return self._initialize_local_camera()
+
             # OPTIMIZACIÓN CRÍTICA: Variables de entorno FFmpeg
             os.environ["OPENCV_FFMPEG_CAPTURE_OPTIONS"] = (
                 "rtsp_transport;udp|"           # UDP para mínima latencia
@@ -393,16 +433,18 @@ class DetectionTapo(QThread):
         try:
             url = 'https://weaponnotificationserver.onrender.com/api/images/'
             
-            files = {'image': open(filepath, 'rb')}
-            data = {
-                'token': self.token,
-                'location': self.location,
-                'receiver': self.receiver,
-                'camera_id': self.camera_id,
-                'detections': str(detections)
-            }
-            
-            response = requests.post(url, files=files, data=data, timeout=10)
+            # Los nombres DEBEN coincidir con el serializer del servidor
+            # (UploadAlertSerializer): userID (= token), location, alertReceiver, image.
+            headers = {'Authorization': 'Token ' + str(self.token)}
+            with open(filepath, 'rb') as img_file:
+                files = {'image': img_file}
+                data = {
+                    'userID': self.token,
+                    'location': self.location,
+                    'alertReceiver': self.receiver,
+                }
+                response = requests.post(url, files=files, data=data,
+                                         headers=headers, timeout=10)
             
             if response.status_code == 200:
                 logging.info(f"[Cámara {self.camera_id}] Enviado al servidor")

--- a/Cliente/App/inference_engine.py
+++ b/Cliente/App/inference_engine.py
@@ -115,12 +115,21 @@ class InferenceEngine:
         logging.info("[Engine] Detenido y modelo liberado")
 
     def _detect_gpu(self):
-        if GPUtil is None:
+        # IMPORTANTE: no basta con que exista una GPU física (GPUtil/nvidia-smi);
+        # torch debe estar compilado con CUDA. Con torch CPU-only, pedir device=0
+        # hace que TODA inferencia falle ("Invalid CUDA 'device=0' requested").
+        try:
+            import torch
+            if not torch.cuda.is_available():
+                return False
+        except Exception:
             return False
+        if GPUtil is None:
+            return True
         try:
             return len(GPUtil.getGPUs()) > 0
         except Exception:
-            return False
+            return True
 
     # ------------------------------------------------------------------ registro / envío
     def register(self, camera_id, callback):

--- a/Cliente/App/monitoringWindowClass.py
+++ b/Cliente/App/monitoringWindowClass.py
@@ -492,7 +492,9 @@ class MonitoringWindow(QMainWindow):
         
         # Validar campos (según la marca)
         brand = config.get('brand', 'tapo')
-        if profiles.brand_uses_custom_path(brand):
+        if profiles.is_local_source(config):
+            valid = True
+        elif profiles.brand_uses_custom_path(brand):
             valid = bool((config.get('path') or '').strip())
         else:
             valid = bool(config['ip'] and config['username'] and config['password'])
@@ -510,25 +512,34 @@ class MonitoringWindow(QMainWindow):
             self, "Probando Conexión",
             f"Conectando a cámara {camera_num}...\nEsto puede tardar unos segundos."
         )
-        
+
         try:
-            os.environ["OPENCV_FFMPEG_CAPTURE_OPTIONS"] = (
-                "rtsp_transport;udp|fflags;nobuffer|flags;low_delay"
-            )
-            
-            cap = cv2.VideoCapture(rtsp_url, cv2.CAP_FFMPEG)
-            
+            if profiles.is_local_source(config):
+                idx = profiles.local_device_index(config)
+                if sys.platform.startswith('win'):
+                    cap = cv2.VideoCapture(idx, cv2.CAP_DSHOW)
+                else:
+                    cap = cv2.VideoCapture(idx)
+            else:
+                os.environ["OPENCV_FFMPEG_CAPTURE_OPTIONS"] = (
+                    "rtsp_transport;udp|fflags;nobuffer|flags;low_delay"
+                )
+                cap = cv2.VideoCapture(rtsp_url, cv2.CAP_FFMPEG)
+
             if cap.isOpened():
                 ret, frame = cap.read()
                 if ret:
                     width = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
                     height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
-                    
+
+                    fuente = (f"Webcam local (índice {profiles.local_device_index(config)})"
+                              if profiles.is_local_source(config)
+                              else f"IP: {config.get('ip', '')}")
                     QMessageBox.information(
                         self, f"✅ Cámara {camera_num} Conectada",
                         f"¡Conexión exitosa!\n\n"
                         f"Resolución: {width}x{height}\n"
-                        f"IP: {config['ip']}\n"
+                        f"{fuente}\n"
                         f"Marca: {profiles.brand_label(config.get('brand', 'tapo'))}"
                     )
                 else:
@@ -571,18 +582,27 @@ class MonitoringWindow(QMainWindow):
 
             # Probar conexión
             rtsp_url = profiles.build_rtsp_url(config)
+            is_local = profiles.is_local_source(config)
 
             try:
-                os.environ["OPENCV_FFMPEG_CAPTURE_OPTIONS"] = (
-                    "rtsp_transport;udp|fflags;nobuffer|flags;low_delay"
-                )
-                
-                cap = cv2.VideoCapture(rtsp_url, cv2.CAP_FFMPEG)
-                
+                if is_local:
+                    idx = profiles.local_device_index(config)
+                    if sys.platform.startswith('win'):
+                        cap = cv2.VideoCapture(idx, cv2.CAP_DSHOW)
+                    else:
+                        cap = cv2.VideoCapture(idx)
+                else:
+                    os.environ["OPENCV_FFMPEG_CAPTURE_OPTIONS"] = (
+                        "rtsp_transport;udp|fflags;nobuffer|flags;low_delay"
+                    )
+                    cap = cv2.VideoCapture(rtsp_url, cv2.CAP_FFMPEG)
+
                 if cap.isOpened():
                     ret, _ = cap.read()
                     if ret:
-                        results.append(f"Cámara {camera_num}: ✅ OK ({config['ip']})")
+                        fuente = (f"webcam {profiles.local_device_index(config)}"
+                                  if is_local else config.get('ip', ''))
+                        results.append(f"Cámara {camera_num}: ✅ OK ({fuente})")
                     else:
                         results.append(f"Cámara {camera_num}: ⚠️ Sin frames")
                     cap.release()
@@ -609,6 +629,9 @@ class MonitoringWindow(QMainWindow):
         if not config.get('location'):
             return False
         brand = config.get('brand', 'tapo')
+        if profiles.is_local_source(config):
+            # Webcam local: solo necesita ubicación (ya validada arriba).
+            return True
         if profiles.brand_uses_custom_path(brand):
             path = (config.get('path') or '').strip()
             if not path:

--- a/Cliente/App/rtsp_profiles.py
+++ b/Cliente/App/rtsp_profiles.py
@@ -19,6 +19,7 @@ BRANDS = [
     ('dahua', 'Dahua'),
     ('reolink', 'Reolink'),
     ('custom', 'Genérica / Otra (ruta manual)'),
+    ('webcam', 'Webcam local (USB / laptop)'),
 ]
 
 # Calidad de stream: clave canónica -> etiqueta
@@ -31,6 +32,8 @@ QUALITIES = [
 _NEEDS_CHANNEL = {'hikvision', 'dahua', 'reolink'}
 # Marcas que muestran un campo de ruta RTSP manual.
 _USES_CUSTOM_PATH = {'custom'}
+# Fuentes locales (no RTSP): webcam USB / cámara de la laptop.
+_LOCAL_SOURCE = {'webcam', 'local', 'usb'}
 
 DEFAULT_BRAND = 'tapo'
 DEFAULT_PORT = 554
@@ -52,6 +55,19 @@ def brand_needs_channel(brand):
 def brand_uses_custom_path(brand):
     """True si la marca usa una ruta RTSP escrita a mano."""
     return (brand or '').lower() in _USES_CUSTOM_PATH
+
+
+def is_local_source(cfg):
+    """True si la cámara es una fuente local (webcam USB / laptop), no RTSP."""
+    return str(cfg.get('brand', '') or '').lower() in _LOCAL_SOURCE
+
+
+def local_device_index(cfg):
+    """Índice de dispositivo OpenCV para una webcam local (0 = cámara por defecto)."""
+    try:
+        return int(cfg.get('device_index', 0))
+    except (ValueError, TypeError):
+        return 0
 
 
 def normalize_quality(cfg):
@@ -110,6 +126,11 @@ def build_rtsp_url(cfg):
     """
     try:
         brand = (cfg.get('brand') or DEFAULT_BRAND).lower()
+
+        if brand in _LOCAL_SOURCE:
+            # Fuente local: no hay URL RTSP; se identifica por índice de dispositivo.
+            return f"webcam:{local_device_index(cfg)}"
+
         user = quote(str(cfg.get('username', '') or ''), safe='')
         pwd = quote(str(cfg.get('password', '') or ''), safe='')
         ip = str(cfg.get('ip', '') or '').strip()

--- a/Cliente/cameras.json
+++ b/Cliente/cameras.json
@@ -1,12 +1,9 @@
 {
     "camera_1": {
-        "name": "Cámara Principal",
-        "ip": "192.168.1.10",
-        "username": "admin",
-        "password": "password",
-        "stream": "stream1",
-        "port": 554,
-        "location": "Entrada Principal",
+        "name": "Webcam Laptop (pruebas)",
+        "brand": "webcam",
+        "device_index": 0,
+        "location": "Laptop local",
         "enabled": true
     },
     "camera_2": {

--- a/Cliente/main.py
+++ b/Cliente/main.py
@@ -212,10 +212,13 @@ class MainApplication(QObject):
             for cam_num, config in cameras.items():
                 logging.info(f"")
                 logging.info(f"Configurando Cámara {cam_num}:")
-                logging.info(f"  IP: {config['ip']}")
-                logging.info(f"  Usuario: {config['username']}")
-                logging.info(f"  Stream: {config['stream']}")
-                logging.info(f"  Ubicación: {config['location']}")
+                if str(config.get('brand', '')).lower() in ('webcam', 'local', 'usb'):
+                    logging.info(f"  Fuente: Webcam local (índice {config.get('device_index', 0)})")
+                else:
+                    logging.info(f"  IP: {config.get('ip', '')}")
+                    logging.info(f"  Usuario: {config.get('username', '')}")
+                    logging.info(f"  Stream: {config.get('stream', '')}")
+                logging.info(f"  Ubicación: {config.get('location', '')}")
 
                 # Crear instancia de DetectionTapo (sin modelo propio: usa el engine compartido)
                 detection = DetectionTapo(

--- a/Server/alertuploadREST/views.py
+++ b/Server/alertuploadREST/views.py
@@ -72,71 +72,62 @@ def send_email_alert(serializer):
 @start_new_thread
 def send_enhanced_email(serializer):
     try:
-        print("Iniciando proceso de envío de correo mejorado vía SendGrid...")
-        
+        print("Iniciando proceso de envío de correo de alerta vía Brevo API HTTP...")
+
         # Extraer datos del serializador
         alert_data = extract_alert_data(serializer)
-        
+
         # Crear el correo con HTML
         subject = f"🚨 ALERTA DE SEGURIDAD - Arma Detectada"
-        
+
         # Texto plano como respaldo
         text_content = create_text_email(alert_data)
-        
+
         # Contenido HTML mejorado
         html_content = create_html_email(alert_data)
-        
-        # Crear correo multipart
-        email = EmailMultiAlternatives(
-            subject=subject,
-            body=text_content,
-            from_email=settings.DEFAULT_FROM_EMAIL,
-            to=[serializer.data['alertReceiver']]
-        )
-        
-        # Adjuntar versión HTML
-        email.attach_alternative(html_content, "text/html")
-        
+
+        receiver = serializer.data['alertReceiver']
+
         print(f"Detalles del correo:")
         print(f"  Asunto: {subject}")
-        print(f"  Para: {serializer.data['alertReceiver']}")
+        print(f"  Para: {receiver}")
         print(f"  De: {settings.DEFAULT_FROM_EMAIL}")
         print(f"  Longitud de contenido HTML: {len(html_content)} caracteres")
-        
-        # Enviar correo vía SendGrid
-        result = email.send(fail_silently=False)
-        
-        print(f"Resultado del envío: {result}")
-        if result == 1:
-            print("✅ Correo mejorado enviado exitosamente vía SendGrid!")
-        else:
-            print("Falló el envío del correo - sin error pero el resultado fue 0")
-            
+
+        # IMPORTANTE: Render bloquea el SMTP saliente. Se envía por la API HTTP
+        # de Brevo (puerto 443), el mismo camino que el reset de contraseña.
+        from detection.email_sender import send_email_async
+        send_email_async(
+            subject=subject,
+            text_content=text_content,
+            to_email=receiver,
+            html_content=html_content,
+        )
+        print("✅ Correo de alerta encolado vía Brevo API HTTP!")
+
     except Exception as e:
         print(f"Error al enviar correo mejorado: {e}")
         import traceback
         print(f"Rastreo completo: {traceback.format_exc()}")
-        
+
         # Respaldo al correo simple
         print("Intentando respaldo a correo simple...")
         send_simple_email_fallback(serializer)
 
 @start_new_thread
 def send_simple_email_fallback(serializer):
-    """Respaldo al método original si el correo HTML falla"""
+    """Respaldo simple (solo texto) también vía API HTTP de Brevo."""
     try:
         alert_data = extract_alert_data(serializer)
-        
-        result = send_mail(
+
+        from detection.email_sender import send_email_async
+        send_email_async(
             subject='🚨 Alerta de Seguridad - Arma Detectada',
-            message=create_text_email(alert_data),
-            from_email=settings.DEFAULT_FROM_EMAIL,
-            recipient_list=[serializer.data['alertReceiver']],
-            fail_silently=False,
+            text_content=create_text_email(alert_data),
+            to_email=serializer.data['alertReceiver'],
         )
-        
-        print(f"Resultado de correo de respaldo vía SendGrid: {result}")
-        
+        print("Correo de respaldo encolado vía Brevo API HTTP")
+
     except Exception as e:
         print(f"Error en correo de respaldo: {e}")
 

--- a/Server/detection/email_sender.py
+++ b/Server/detection/email_sender.py
@@ -1,88 +1,78 @@
 """
-Sistema de envío de emails usando SendGrid API HTTP (no SMTP)
-SMTP está bloqueado en Render - usamos HTTP API que funciona perfectamente
+Sistema de envío de emails usando la API HTTP de Brevo (Sendinblue).
+Render bloquea el SMTP saliente (puerto 587), por eso se usa la API HTTP
+(https://api.brevo.com/v3/smtp/email, puerto 443) que NO está bloqueada.
 """
 from threading import Thread
 from django.template.loader import render_to_string
 from django.conf import settings
 import logging
 import os
+import requests
 
 logger = logging.getLogger(__name__)
 
-# Intentar importar sendgrid
-try:
-    from sendgrid import SendGridAPIClient
-    from sendgrid.helpers.mail import Mail, Email, To, Content
-    SENDGRID_AVAILABLE = True
-    logger.info("✅ SendGrid API disponible")
-except ImportError:
-    SENDGRID_AVAILABLE = False
-    logger.warning("⚠️ SendGrid no instalado - pip install sendgrid")
+BREVO_API_URL = "https://api.brevo.com/v3/smtp/email"
+
+
+def _get_brevo_api_key():
+    """API key de Brevo (empieza con 'xkeysib-')."""
+    return os.environ.get('BREVO_API_KEY', getattr(settings, 'BREVO_API_KEY', '') or '')
 
 
 def send_email_async(subject, text_content, to_email, html_content=None, from_email=None):
     """
-    Envía un email usando SendGrid API HTTP (no SMTP bloqueado por Render)
-    Se ejecuta en un thread separado para no bloquear la respuesta
+    Envía un email usando la API HTTP de Brevo (no SMTP bloqueado por Render).
+    Se ejecuta en un thread separado para no bloquear la respuesta HTTP.
     """
     if not from_email:
         from_email = settings.DEFAULT_FROM_EMAIL
-    
+
     def _send():
         try:
-            if not SENDGRID_AVAILABLE:
-                logger.error("❌ SendGrid no instalado")
-                logger.error("   Ejecuta: pip install sendgrid")
+            api_key = _get_brevo_api_key()
+            if not api_key:
+                logger.error("❌ BREVO_API_KEY no configurado (revisa .env / Render)")
                 return False
-            
-            # Obtener API Key
-            api_key = os.environ.get('SENDGRID_API_KEY', settings.EMAIL_HOST_PASSWORD)
-            
-            if not api_key or not api_key.startswith('SG.'):
-                logger.error("❌ SENDGRID_API_KEY no configurado o inválido")
-                logger.error(f"   API Key actual: {api_key[:20] if api_key else 'None'}...")
-                return False
-            
-            logger.info(f"📧 Enviando email a {to_email} vía SendGrid API HTTP...")
-            
-            # Crear mensaje con SendGrid API
-            message = Mail(
-                from_email=Email(from_email),
-                to_emails=To(to_email),
-                subject=subject,
-                plain_text_content=Content("text/plain", text_content)
-            )
-            
-            # Agregar HTML si existe
+
+            logger.info(f"📧 Enviando email a {to_email} vía Brevo API HTTP...")
+
+            payload = {
+                "sender": {"email": from_email, "name": "Weapon Detection System"},
+                "to": [{"email": to_email}],
+                "subject": subject,
+                "textContent": text_content,
+            }
             if html_content:
-                message.add_content(Content("text/html", html_content))
-            
-            # Enviar vía API HTTP (puerto 443 - NO bloqueado por Render)
-            sg = SendGridAPIClient(api_key)
-            response = sg.send(message)
-            
-            # SendGrid API retorna 202 si fue aceptado
-            if response.status_code == 202:
-                logger.info(f"✅ Email enviado exitosamente a {to_email}")
-                logger.info(f"   Status: {response.status_code} (Accepted)")
+                payload["htmlContent"] = html_content
+
+            headers = {
+                "api-key": api_key,
+                "Content-Type": "application/json",
+                "accept": "application/json",
+            }
+
+            response = requests.post(BREVO_API_URL, json=payload, headers=headers, timeout=15)
+
+            # Brevo devuelve 201 (Created) cuando acepta el mensaje.
+            if response.status_code in (200, 201):
+                logger.info(f"✅ Email enviado exitosamente a {to_email} (status {response.status_code})")
                 return True
             else:
-                logger.warning(f"⚠️ SendGrid retornó status inesperado: {response.status_code}")
-                logger.warning(f"   Body: {response.body}")
+                logger.warning(f"⚠️ Brevo devolvió status inesperado: {response.status_code}")
+                logger.warning(f"   Body: {response.text}")
                 return False
-                
+
         except Exception as e:
-            logger.error(f"❌ Error enviando email vía SendGrid API: {str(e)}")
+            logger.error(f"❌ Error enviando email vía Brevo API: {str(e)}")
             import traceback
             logger.error(traceback.format_exc())
             return False
-    
-    # Lanzar en thread daemon (muere con el proceso principal)
+
     thread = Thread(target=_send, daemon=True)
     thread.start()
-    
-    logger.info(f"🚀 Email encolado para {to_email} vía API HTTP")
+
+    logger.info(f"🚀 Email encolado para {to_email} vía Brevo API HTTP")
     return True
 
 

--- a/Server/webdev/settings.py
+++ b/Server/webdev/settings.py
@@ -173,53 +173,54 @@ STATICFILES_DIRS =[
 MEDIA_ROOT = 'static/images'
 
 # ==========================================
-# ✅ SENDGRID EMAIL CONFIGURATION (NUEVO)
+# ✅ GMAIL SMTP EMAIL CONFIGURATION
 # ==========================================
+# Se usa Gmail vía SMTP con una "App Password" (contraseña de aplicación).
+# Credenciales por variables de entorno (.env / Render):
+#   EMAIL_HOST_USER      = tu-correo@gmail.com
+#   EMAIL_HOST_PASSWORD  = app password de 16 caracteres (sin espacios)
 EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
-EMAIL_HOST = 'smtp.sendgrid.net'
-EMAIL_PORT = 587
+EMAIL_HOST = os.environ.get('EMAIL_HOST', 'smtp.gmail.com')
+EMAIL_PORT = int(os.environ.get('EMAIL_PORT', '587'))
 EMAIL_USE_TLS = True
 EMAIL_USE_SSL = False
-EMAIL_HOST_USER = 'apikey'  # ⚠️ Siempre es 'apikey' para SendGrid
-EMAIL_HOST_PASSWORD = os.environ.get('SENDGRID_API_KEY', '')
-DEFAULT_FROM_EMAIL = os.environ.get('SENDGRID_FROM_EMAIL', 'noreply@weapondetection.com')
+EMAIL_HOST_USER = os.environ.get('EMAIL_HOST_USER', '')
+# Se limpian espacios: Google muestra la app password en bloques de 4 (xxxx xxxx ...).
+EMAIL_HOST_PASSWORD = os.environ.get('EMAIL_HOST_PASSWORD', '').replace(' ', '')
+DEFAULT_FROM_EMAIL = os.environ.get('DEFAULT_FROM_EMAIL', EMAIL_HOST_USER or 'noreply@weapondetection.com')
 SERVER_EMAIL = DEFAULT_FROM_EMAIL
-EMAIL_TIMEOUT = 30  # SendGrid es más rápido que Gmail
+EMAIL_TIMEOUT = 30
 
-# Validación de configuración de SendGrid
-SENDGRID_API_KEY = os.environ.get('SENDGRID_API_KEY')
-SENDGRID_FROM_EMAIL = os.environ.get('SENDGRID_FROM_EMAIL')
+# ==========================================
+# ✅ BREVO API HTTP (envío real de correos)
+# ==========================================
+# Render bloquea el SMTP saliente, así que alertas y reset de contraseña se
+# envían por la API HTTP de Brevo (puerto 443). La API key empieza con 'xkeysib-'.
+# El remitente (DEFAULT_FROM_EMAIL) DEBE estar verificado en Brevo (Senders).
+BREVO_API_KEY = os.environ.get('BREVO_API_KEY', '')
+if not BREVO_API_KEY:
+    print("\n[!] BREVO_API_KEY no configurado - los correos NO se enviaran.\n")
 
-if not SENDGRID_API_KEY:
+if not EMAIL_HOST_USER or not EMAIL_HOST_PASSWORD:
     import warnings
     warnings.warn(
-        "⚠️ SENDGRID_API_KEY no configurado. "
-        "Los emails no se enviarán. Revisa tu archivo .env",
+        "⚠️ Gmail no configurado. Los emails no se enviarán. "
+        "Agrega EMAIL_HOST_USER y EMAIL_HOST_PASSWORD a tu .env / Render.",
         RuntimeWarning
     )
     print("\n" + "="*60)
-    print("❌ CONFIGURACIÓN DE SENDGRID INCOMPLETA")
+    print("[X] CONFIGURACION DE GMAIL INCOMPLETA")
     print("="*60)
-    print("Necesitas agregar a tu .env:")
-    print("  SENDGRID_API_KEY=tu-api-key-aqui")
-    print("  SENDGRID_FROM_EMAIL=tu-email-verificado@tudominio.com")
+    print("Necesitas agregar a tu .env / Render:")
+    print("  EMAIL_HOST_USER=tu-correo@gmail.com")
+    print("  EMAIL_HOST_PASSWORD=app-password-de-16-caracteres")
     print("="*60 + "\n")
-elif not SENDGRID_FROM_EMAIL:
-    import warnings
-    warnings.warn(
-        "⚠️ SENDGRID_FROM_EMAIL no configurado. "
-        "Usando email por defecto, pero debes verificarlo en SendGrid.",
-        RuntimeWarning
-    )
-    print("\n⚠️ SENDGRID_FROM_EMAIL no configurado - usando default\n")
 else:
     print("\n" + "="*60)
-    print("✅ SENDGRID CONFIGURADO CORRECTAMENTE")
+    print("[OK] GMAIL SMTP CONFIGURADO")
     print("="*60)
-    print(f"   From Email: {SENDGRID_FROM_EMAIL}")
-    print(f"   API Key: {'*' * 20}{SENDGRID_API_KEY[-8:]}")
-    print(f"   SMTP Host: {EMAIL_HOST}")
-    print(f"   SMTP Port: {EMAIL_PORT}")
+    print(f"   From Email: {DEFAULT_FROM_EMAIL}")
+    print(f"   SMTP Host: {EMAIL_HOST}:{EMAIL_PORT}")
     print("="*60 + "\n")
 
 # Amazon S3 Configuration


### PR DESCRIPTION
- Cliente: agrega fuente 'webcam' local (cámara de laptop) además de RTSP; cámara 1 usa la webcam por índice de dispositivo para pruebas.
- Cliente: el motor de inferencia cae a CPU cuando torch no tiene CUDA (antes GPUtil detectaba la GPU física y pedía device=0, fallando toda inferencia).
- Cliente: corrige nombres del POST de alerta (userID/alertReceiver) que el refactor había roto, y usa headers de auth.
- Servidor: envío de correo de alertas y reset por la API HTTP de Brevo (Render bloquea SMTP; SendGrid trial vencido). Config por BREVO_API_KEY.