### PR TITLE
fix(cliente): crashes del empaquetado, contadores en vivo e ícono de ventanas

### DIFF
--- a/Cliente/App/detectionWindowDual.py
+++ b/Cliente/App/detectionWindowDual.py
@@ -363,11 +363,19 @@ class DetectionWindowDual(QMainWindow):
     
     def update_camera_image(self, camera_id, image):
         """Actualizar imagen de cámara"""
+        # Ignorar señales en cola que llegan DURANTE el cierre: la ventana (y sus
+        # QLabel en C++) puede estar ya destruida (deleteLater), y tocar
+        # setPixmap sobre un widget muerto provoca un access violation (crash
+        # nativo al Detener el sistema). Ver _shutdown_and_emit (_is_closing).
+        if self._is_closing:
+            return
         if camera_id in self.camera_labels:
             self.camera_labels[camera_id].setPixmap(QPixmap.fromImage(image))
-    
+
     def update_camera_status(self, camera_id, message):
         """Actualizar estado de cámara"""
+        if self._is_closing:
+            return
         if camera_id in self.status_labels:
             # Extraer solo texto relevante (quitar [Cámara N])
             clean_msg = message.split(']')[-1].strip() if ']' in message else message
@@ -383,6 +391,8 @@ class DetectionWindowDual(QMainWindow):
     
     def update_system_resources(self, data):
         """Actualizar información de recursos del sistema"""
+        if self._is_closing:
+            return
         try:
             self.cpu_label.setText(f"CPU: {data.get('cpu', 0):.1f}%")
             self.ram_label.setText(f"RAM: {data.get('memory', 0):.1f}%")
@@ -396,6 +406,8 @@ class DetectionWindowDual(QMainWindow):
     
     def on_weapon_detected(self, message):
         """Manejar detección de armas"""
+        if self._is_closing:
+            return
         logging.warning(f"DETECCIÓN: {message}")
         
         # Actualizar contador de detecciones

--- a/Cliente/App/detection_tapo.py
+++ b/Cliente/App/detection_tapo.py
@@ -335,13 +335,18 @@ class DetectionTapo(QThread):
 
         msg = f"[Cámara {self.camera_id}] {len(detections)} objetos detectados"
         logging.info(msg)
-        self.weaponDetected.emit(msg)
 
-        # Guardar y enviar (rate-limitado por capture_interval), igual que antes
+        # Guardar y enviar (rate-limitado por capture_interval), igual que antes.
+        # La señal weaponDetected (que incrementa el contador de la UI) se emite
+        # SOLO cuando realmente se guarda y envía al servidor, para que el
+        # contador coincida 1:1 con los envíos/registros del servidor (antes se
+        # emitía en cada ciclo de inferencia ~cada 2s, por eso la UI mostraba
+        # más detecciones que imágenes enviadas).
         current_time = time.time()
         if (current_time - self.last_capture_time) >= self.capture_interval:
             self.saveDetection(annotated_frame, detections)
             self.last_capture_time = current_time
+            self.weaponDetected.emit(msg)
     
     def update_ui(self, frame):
         """Actualizar UI OPTIMIZADO"""

--- a/Cliente/App/inference_engine.py
+++ b/Cliente/App/inference_engine.py
@@ -194,7 +194,10 @@ class InferenceEngine:
                 # DetectionTapo solo emite señales (thread-safe) y guarda/sube.
                 callback(annotated, detections)
             except Exception as e:
-                logging.error(f"[Engine] Error procesando cámara {cid}: {e}")
+                # logging.exception conserva el traceback completo (antes solo
+                # el mensaje). Cubre TODO el path posterior a la detección:
+                # _infer + callback -> on_inference_result -> saveDetection.
+                logging.exception(f"[Engine] Error procesando cámara {cid}: {e}")
             finally:
                 with self._lock:
                     self._inflight.discard(cid)

--- a/Cliente/App/loginWindowClass.py
+++ b/Cliente/App/loginWindowClass.py
@@ -88,9 +88,15 @@ class LoginWindow(QMainWindow):
 
     def customize_title_bar(self):
         """Personaliza la barra de título"""
-        icon_path = self.resource_path('Assets/icon.png')
+        # El ícono real de la app es UI/icon.ico (el mismo que usa el .exe).
+        # Antes se buscaba 'Assets/icon.png', ruta que no existe, por lo que el
+        # setWindowIcon nunca se ejecutaba y la ventana mostraba el ícono
+        # genérico de Windows.
+        icon_path = self.resource_path('UI/icon.ico')
         if os.path.exists(icon_path):
             self.setWindowIcon(QIcon(icon_path))
+        else:
+            logging.warning(f"Ícono de login no encontrado en: {icon_path}")
 
     def fix_component_positioning(self):
         """Arregla el posicionamiento y dimensiones de los componentes"""

--- a/Cliente/App/monitoringWindowClass.py
+++ b/Cliente/App/monitoringWindowClass.py
@@ -192,15 +192,17 @@ class MonitoringWindow(QMainWindow):
         
         enabled_count = len([c for c in self.cameras.values() if c.get('enabled', True)])
         
-        stats_label = QLabel(
+        # Se guarda como atributo para poder refrescarlo en tiempo real cuando
+        # se marca/desmarca cualquier checkbox de habilitación.
+        self.stats_label = QLabel(
             f"📊 Total: {total_cameras} | "
             f"✅ Habilitadas: {enabled_count} | "
             f"⚪ Deshabilitadas: {total_cameras - enabled_count}"
         )
-        stats_label.setFont(QFont("Segoe UI", 9))
-        stats_label.setStyleSheet("color: #34495e; padding: 5px;")
-        
-        stats_layout.addWidget(stats_label)
+        self.stats_label.setFont(QFont("Segoe UI", 9))
+        self.stats_label.setStyleSheet("color: #34495e; padding: 5px;")
+
+        stats_layout.addWidget(self.stats_label)
         main_layout.addLayout(stats_layout)
         
         # ==========================================
@@ -294,6 +296,32 @@ class MonitoringWindow(QMainWindow):
         self.setWindowTitle(f"Sistema Multi-Cámara ({total_cameras}) - Weapon Detection")
         self.setMinimumSize(900, window_height)
     
+    def refresh_camera_stats(self):
+        """Recalcular en tiempo real Total/Habilitadas/Deshabilitadas y el texto
+        del botón "Iniciar Sistema", leyendo el estado actual de cada checkbox.
+
+        Se invoca cada vez que se marca/desmarca un checkbox de habilitación y
+        una vez al cargar la configuración inicial.
+        """
+        try:
+            total = len(self.camera_widgets)
+            enabled = sum(
+                1 for w in self.camera_widgets.values()
+                if w['enabled'].isChecked()
+            )
+            disabled = total - enabled
+
+            if hasattr(self, 'stats_label'):
+                self.stats_label.setText(
+                    f"📊 Total: {total} | "
+                    f"✅ Habilitadas: {enabled} | "
+                    f"⚪ Deshabilitadas: {disabled}"
+                )
+            if hasattr(self, 'startButton'):
+                self.startButton.setText(f"▶️ Iniciar Sistema ({enabled} cámaras)")
+        except Exception as e:
+            logging.exception(f"Error al refrescar estadísticas de cámaras: {e}")
+
     def create_camera_tab(self, camera_key, camera_num):
         """Crear tab de configuración para una cámara individual"""
         # Crear widget principal con scroll
@@ -326,6 +354,8 @@ class MonitoringWindow(QMainWindow):
         enable_checkbox = QCheckBox(f"Habilitar Cámara {camera_num}")
         enable_checkbox.setChecked(True)
         enable_checkbox.setFont(QFont("Segoe UI", 10))
+        # Recalcular contadores y texto del botón en tiempo real al alternar.
+        enable_checkbox.stateChanged.connect(self.refresh_camera_stats)
         widgets['enabled'] = enable_checkbox
         
         status_layout.addWidget(enable_checkbox)
@@ -402,6 +432,10 @@ class MonitoringWindow(QMainWindow):
                     widgets['enabled'].setChecked(config.get('enabled', True))
 
             logging.info(f"Configuraciones cargadas para {len(self.camera_widgets)} cámara(s)")
+
+            # Reflejar el estado real (enabled) recién cargado del JSON en el
+            # resumen y en el texto del botón.
+            self.refresh_camera_stats()
 
         except Exception as e:
             logging.error(f"Error al cargar configuraciones: {e}")

--- a/Cliente/main.py
+++ b/Cliente/main.py
@@ -3,6 +3,106 @@ import sys
 import os
 import logging
 import subprocess
+import faulthandler
+import threading
+import traceback
+
+# ==========================================================================
+# (1-B) FIX CRASH: OpenMP duplicado (libiomp5md.dll).
+# El .spec de producción copia las DLLs de Intel MKL + libiomp5md.dll a la
+# raíz del dist, y PyTorch trae su PROPIA copia de OpenMP. Con dos runtimes de
+# OpenMP cargados, Intel ABORTA el proceso ("OMP: Error #15 ... already
+# initialized"). Como el ejecutable es windowed (console=False), ese abort no
+# muestra mensaje: la app se cierra en silencio al ejecutar la primera
+# inferencia. Estas variables deben quedar FÍSICAMENTE ANTES de importar
+# torch/cv2/ultralytics (los imports de App.* de abajo ya los arrastran).
+os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
+os.environ.setdefault("OMP_NUM_THREADS", "1")
+
+
+def _base_dir():
+    """Directorio base compatible con PyInstaller (frozen) y desarrollo."""
+    if getattr(sys, 'frozen', False):
+        return os.path.dirname(sys.executable)
+    return os.path.dirname(os.path.abspath(__file__))
+
+
+def resource_path(relative_path):
+    """Ruta absoluta a un recurso empaquetado (UI/icon.ico, etc.).
+
+    Resuelve tanto en desarrollo como dentro del bundle de PyInstaller:
+    - frozen: sys._MEIPASS (carpeta temporal donde se extraen los datos).
+    - desarrollo: directorio de este archivo (UI/ es hermano de main.py).
+    """
+    if hasattr(sys, '_MEIPASS'):
+        base = sys._MEIPASS
+    else:
+        base = os.path.dirname(os.path.abspath(__file__))
+    return os.path.join(base, relative_path)
+
+
+def resolve_data_path(relative_path):
+    """Resolver un recurso de datos (p.ej. el modelo YOLO) de forma robusta.
+
+    Usa la ruta relativa tal cual si existe respecto al cwd (comportamiento de
+    desarrollo, sin cambios). Si no existe (típico en el ejecutable empaquetado,
+    donde el cwd es el del .exe y los datos viven en el bundle), cae a
+    resource_path(). Funciona igual en PyInstaller 5 (datos en la raíz) y 6
+    (datos en _internal/). No cambia la arquitectura de inferencia.
+    """
+    if os.path.exists(relative_path):
+        return relative_path
+    bundled = resource_path(relative_path)
+    return bundled if os.path.exists(bundled) else relative_path
+
+
+# (1-A) Instrumentación para capturar CUALQUIER crash nativo futuro.
+# faulthandler vuelca el stack de C/Python ante un abort/segfault (cosa que un
+# try/except de Python NO puede interceptar) a crash_dump.log; sys/threading
+# excepthook registran cualquier excepción de Python no capturada en el log.
+# No cambia el comportamiento normal de la app.
+_crash_dump_file = None
+
+
+def _install_crash_handlers():
+    global _crash_dump_file
+    try:
+        dump_path = os.path.join(_base_dir(), 'crash_dump.log')
+        # Mantener el archivo abierto durante toda la vida del proceso: si se
+        # cierra, faulthandler no podría escribir en el momento del crash.
+        _crash_dump_file = open(dump_path, 'a', buffering=1, encoding='utf-8')
+        faulthandler.enable(file=_crash_dump_file, all_threads=True)
+    except Exception as e:
+        # Si no se puede abrir el archivo, al menos a stderr.
+        try:
+            faulthandler.enable(all_threads=True)
+        except Exception:
+            pass
+        print(f"No se pudo instalar faulthandler en archivo: {e}")
+
+    def _log_uncaught(exc_type, exc_value, exc_tb):
+        if issubclass(exc_type, KeyboardInterrupt):
+            sys.__excepthook__(exc_type, exc_value, exc_tb)
+            return
+        logging.exception(
+            "Excepción no capturada (hilo principal): %s",
+            exc_value,
+            exc_info=(exc_type, exc_value, exc_tb),
+        )
+
+    sys.excepthook = _log_uncaught
+
+    # threading.excepthook existe desde Python 3.8.
+    if hasattr(threading, 'excepthook'):
+        def _log_thread_uncaught(args):
+            logging.error(
+                "Excepción no capturada en hilo '%s':\n%s",
+                getattr(args.thread, 'name', '?'),
+                ''.join(traceback.format_exception(
+                    args.exc_type, args.exc_value, args.exc_traceback)),
+            )
+        threading.excepthook = _log_thread_uncaught
+
 
 # En Windows, evitar que los subprocesos (p.ej. nvidia-smi, que GPUtil invoca
 # cada pocos segundos durante la deteccion) abran ventanas de consola que parpadean.
@@ -19,6 +119,7 @@ if sys.platform.startswith('win'):
 
 from PyQt5.QtWidgets import QApplication
 from PyQt5.QtCore import QObject, QSharedMemory
+from PyQt5.QtGui import QIcon
 from App.loginWindowClass import LoginWindow
 from App.monitoringWindowClass import MonitoringWindow
 from App.detectionWindowDual import DetectionWindowDual
@@ -95,11 +196,27 @@ class MainApplication(QObject):
     def __init__(self):
         super().__init__()
         setup_logging()
-        
+        # Instalar handlers de crash DESPUÉS de configurar logging (para que el
+        # excepthook pueda registrar) pero antes de crear ventanas/hilos.
+        _install_crash_handlers()
+
         # Configurar aplicación Qt
         self.app = QApplication(sys.argv)
         self.app.setApplicationName("Weapon Detection System")
         self.app.setApplicationVersion("2.0 Multi-Camera")
+
+        # Ícono a nivel de aplicación: lo heredan TODAS las ventanas (Login,
+        # Monitoring, DetectionDual) y los QMessageBox por defecto. Antes solo
+        # el ejecutable/barra de tareas tenían logo; las ventanas mostraban el
+        # ícono genérico de Windows.
+        try:
+            icon_file = resource_path(os.path.join('UI', 'icon.ico'))
+            if os.path.exists(icon_file):
+                self.app.setWindowIcon(QIcon(icon_file))
+            else:
+                logging.warning(f"Ícono no encontrado en: {icon_file}")
+        except Exception as e:
+            logging.exception(f"No se pudo establecer el ícono de la aplicación: {e}")
         
         # Estado de la aplicación
         self.current_window = None
@@ -185,8 +302,9 @@ class MainApplication(QObject):
 
             # Crear UN motor de inferencia COMPARTIDO (carga el modelo UNA sola vez
             # para todas las cámaras, en vez de una copia por cámara).
+            model_path = resolve_data_path(GLOBAL_CONFIG['model_path'])
             self.engine = InferenceEngine(
-                GLOBAL_CONFIG['model_path'],
+                model_path,
                 conf=GLOBAL_CONFIG.get('confidence_threshold', 0.5),
                 iou=0.45,
                 max_det=GLOBAL_CONFIG.get('max_detections', 10),

--- a/Cliente/weapon_detection_prod.spec
+++ b/Cliente/weapon_detection_prod.spec
@@ -20,10 +20,12 @@ app_name = "WeaponDetectionSystem"
 # Datos adicionales (van a la raiz del dist en modo onedir)
 added_files = [
     ('UI/*.ui', 'UI'),
+    ('UI/icon.ico', 'UI'),   # icono de ventana en runtime (setWindowIcon), resuelto por resource_path
     ('model/last.pt', 'model'),
     ('Styles/*.py', 'Styles'),
     ('requirements*.txt', '.'),
     ('config/settings.ini', '.'),
+    ('cameras.json', '.'),
 ]
 
 # (2) CRITICO: recolectar el set completo de DLLs de Intel MKL + OpenMP


### PR DESCRIPTION
## Resumen
Corrige los 3 problemas reportados en la app de escritorio empaquetada (Cliente/), más 2 issues detectados durante la verificación.

## Crash (la app empaquetada se cerraba en silencio)
- **OpenMP duplicado (`libiomp5md.dll`)**: se fijan `KMP_DUPLICATE_LIB_OK=TRUE` y `OMP_NUM_THREADS=1` **antes** de importar torch/cv2/ultralytics. Era un abort nativo sin consola al ejecutar la primera inferencia.
- **Crash al Detener el sistema**: guardas `_is_closing` en los slots de `DetectionWindowDual` para ignorar señales en cola que llegaban a widgets ya destruidos (access violation). Confirmado con el traceback capturado por faulthandler.
- **Instrumentación**: `faulthandler` -> `crash_dump.log` + `sys/threading.excepthook` para capturar cualquier crash futuro con traza real. `logging.exception` en el worker de inferencia.
- **Ruta del modelo robusta** (`resolve_data_path`) para dev y empaquetado (PyInstaller 5 y 6).

## Contadores y botón en tiempo real
`refresh_camera_stats()` recalcula Total/Habilitadas/Deshabilitadas y el texto del botón al alternar cualquier checkbox.

## Contador = envíos reales
`weaponDetected` se emite solo cuando se guarda y envía al servidor (rate-limitado), no en cada ciclo de inferencia.

## Ícono en todas las ventanas
`setWindowIcon` a nivel de `QApplication` (`UI/icon.ico` vía `resource_path`), corrección de ruta en Login y empaquetado del `.ico` en el `.spec`.

## Verificación
- Detección en vivo sin crash (subida al servidor OK).
- Contadores probados headless (5→4→3→4).
- Arranque del empaquetado limpio, `crash_dump.log` vacío.

**Nota:** para el artefacto de producción, reconstruir con el toolchain habitual (PyInstaller 5.13.2 en entorno conda).

🤖 Generated with [Claude Code](https://claude.com/claude-code)